### PR TITLE
Disable alwaysOn and enable health check

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -134,6 +134,9 @@ resource appServiceWeb 'Microsoft.Web/sites@2022-09-01' = {
     serverFarmId: appServicePlan.id
     httpsOnly: true
     virtualNetworkSubnetId: virtualNetwork.properties.subnets[0].id
+    siteConfig: {
+      healthCheckPath: '/healthz'
+    }
   }
 }
 
@@ -141,7 +144,7 @@ resource appServiceWebConfig 'Microsoft.Web/sites/config@2022-09-01' = {
   parent: appServiceWeb
   name: 'web'
   properties: {
-    alwaysOn: true
+    alwaysOn: false
     cors: {
       allowedOrigins: [
         'http://localhost:3000'


### PR DESCRIPTION
### Motivation and Context

Addressing issue: https://github.com/microsoft/semantic-kernel/issues/1702

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
Instead of mapping / to /healthz, we decided to disable alwaysOn and enable App Service health check. This is because mapping / to /healthz creates a dependency on the deployment setup and makes the code harder to maintain, i.e when alwaysOn is disabled, there is really not point at mapping the route. Thus, disabling alwaysOn and enabling App service health check is a cleaner solution.
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#dev-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
