### PR TITLE
Setting up CI/CD pipeline to cancel when a new push happens.

### DIFF
--- a/.github/workflows/copilot-deploy-pipeline.yml
+++ b/.github/workflows/copilot-deploy-pipeline.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
### Motivation and Context

When something is pushed to main we trigger the deployment to our int environment. If a new push happens when the pipeline is already running, the current run should be canceled. 

### Description

Setting up CI/CD pipeline to cancel when a new push happens.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#dev-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
