### PR TITLE
🔧 Update .eslintrc.js: set tsconfigRootDir to 'webapp'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,8 @@ module.exports = {
     ],
     ignorePatterns: ['build', '.*.js', 'node_modules'],
     parserOptions: {
-        project: './tsconfig.json',
+        project: 'tsconfig.json',
+        tsconfigRootDir: 'webapp',
         ecmaVersion: 'latest',
         sourceType: 'module',
     },


### PR DESCRIPTION
## Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Setting [tsconfigRootDir](https://typescript-eslint.io/architecture/parser#tsconfigrootdir) to webapp, which would make the parser resolve webapp relative to .eslintrc.js.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
By default, the projects (in parserOptions) are resolved relative to the current working directory. Since eslint is run in a different working directory to webapp (the folder containing tsconfig.json), @typescript-eslint/parser was not be able to locate the file.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
~~- [ ] All unit tests pass, and I have added new tests where possible~~
- [x] I didn't break anyone :smile:
