### PR TITLE
Fix Persona tab state not updated bug

### DIFF
--- a/webapp/src/components/chat/persona/PromptEditor.tsx
+++ b/webapp/src/components/chat/persona/PromptEditor.tsx
@@ -33,7 +33,12 @@ const useClasses = makeStyles({
     },
 });
 
+// The number of rows in the textarea.
+// Specifies the height in average character heights.
+const Rows = 8;
+
 interface PromptEditorProps {
+    chatId: string;
     title: string;
     prompt: string;
     isEditable: boolean;
@@ -41,14 +46,25 @@ interface PromptEditorProps {
     modificationHandler?: (value: string) => Promise<void>;
 }
 
-export const PromptEditor: React.FC<PromptEditorProps> = ({ title, prompt, isEditable, info, modificationHandler }) => {
+export const PromptEditor: React.FC<PromptEditorProps> = ({
+    chatId,
+    title,
+    prompt,
+    isEditable,
+    info,
+    modificationHandler,
+}) => {
     const classes = useClasses();
     const dispatch = useAppDispatch();
     const [value, setValue] = React.useState<string>(prompt);
 
     React.useEffect(() => {
+        // Taking a dependency on the chatId because the value state needs
+        // to be reset when the chatId changes. Otherwise, the value may
+        // not be updated when the user switches between chats that has
+        // the same prompt.
         setValue(prompt);
-    }, [prompt]);
+    }, [chatId, prompt]);
 
     const onSaveButtonClick = () => {
         if (modificationHandler) {
@@ -79,6 +95,7 @@ export const PromptEditor: React.FC<PromptEditorProps> = ({ title, prompt, isEdi
             <Textarea
                 resize="vertical"
                 value={value}
+                rows={Rows}
                 disabled={!isEditable}
                 onChange={(_event, data) => {
                     setValue(data.value);

--- a/webapp/src/components/chat/tabs/PersonaTab.tsx
+++ b/webapp/src/components/chat/tabs/PersonaTab.tsx
@@ -40,6 +40,7 @@ export const PersonaTab: React.FC = () => {
         <TabView title="Persona" learnMoreDescription="personas" learnMoreLink=" https://aka.ms/sk-intro-to-personas ">
             <PromptEditor
                 title="Meta Prompt"
+                chatId={selectedId}
                 prompt={chatState.systemDescription}
                 isEditable={true}
                 info="The prompt that defines the chat bot's persona."
@@ -58,12 +59,14 @@ export const PersonaTab: React.FC = () => {
             />
             <PromptEditor
                 title="Short Term Memory"
+                chatId={selectedId}
                 prompt={`<label>: <details>\n${shortTermMemory}`}
                 isEditable={false}
                 info="Extract information for a short period of time, such as a few seconds or minutes. It should be useful for performing complex cognitive tasks that require attention, concentration, or mental calculation."
             />
             <PromptEditor
                 title="Long Term Memory"
+                chatId={selectedId}
                 prompt={`<label>: <details>\n${longTermMemory}`}
                 isEditable={false}
                 info="Extract information that is encoded and consolidated from other memory types, such as working memory or sensory memory. It should be useful for maintaining and recalling one's personal identity, history, and knowledge over time."


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
When users are switching between conversations, the prompt editor may not update its contents if the prompt has been edited but not saved. This is because the value state is not updated when the original prompts of two chats are the same, the useEffect hook will not get triggered.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Make an extra dependency on the chatId to make the value state is updated each time users switch conversations.
2. Increase the height of the text area in the prompt editor.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
