### PR TITLE
Add configuration for web api auth via Azure AD, and extend readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ First, let’s set up and verify the back-end API server is running.
 
    1. Give the app registration a name
 
-   2. As *Supported account type* choose `Accounts in this organizational directory only (Single tenant)`
+   2. As *Supported account type* choose `Accounts in any organizational directory and personal Microsoft Accounts`
 
    3. Do not configure a *Redirect Uri*
 
@@ -167,7 +167,7 @@ First, let’s set up and verify the back-end API server is running.
 
    4. Select the tab *My APIs*
 
-   5. Chooise the app registration representing the web api backend
+   5. Choose the app registration representing the web api backend
 
    6. Select permissions `access_as_user`
 
@@ -176,7 +176,7 @@ First, let’s set up and verify the back-end API server is running.
 5. Update frontend web app configuration
    1. Open *.env* file
 
-   2. Set the value of `REACT_APP_AAD_API_SCOPE` to your application ID URI
+   2. Set the value of `REACT_APP_AAD_API_SCOPE` to your application ID URI followed by the scope `access_as_user`, e.g. `api://12341234-1234-1234-1234-123412341234/access_as_user`
 
 6. Update backend web api configuration
    1. Open *appsettings.json*

--- a/README.md
+++ b/README.md
@@ -127,6 +127,62 @@ First, let’s set up and verify the back-end API server is running.
 2. Have fun!
    > **Note:** Each chat interaction will call Azure OpenAI/OpenAI which will use tokens that you may be billed for.
 
+## (Optional) Enable backend authorization via Azure AD
+
+1. Ensure you created the required application registration mentioned in [Start the WebApp FrontEnd application](#start-the-webapp-frontend-application)
+2. Create a second application registration to represent the web api
+   > For more details on creating an application registration, go [here](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+
+   1. Give the app registration a name
+
+   2. As *Supported account type* choose `Accounts in this organizational directory only (Single tenant)`
+
+   3. Do not configure a *Redirect Uri*
+
+3. Expose an API within the second app registration
+   1. Select *Expose an API* from the menu
+
+   2. Add an *Application ID URI*
+      1. This will generate an `api://` URI with a generated for you
+
+      2. Click *Save* to store the generated URI
+      
+   3. Add a scope for `access_as_user`
+      1. Click *Add scope*
+
+      2. Set *Scope name* to `access_as_user`
+
+      3. Set *Who can consent* to *Admins and users*
+
+      4. Set *Admin consent display name* and *User consent display name* to `Access copilot chat as a user`
+
+      5. Set *Admin consent description* and *User consent description* to `Allows the accesses to the Copilot chat web API as a user`
+
+4. Add permissions to web app frontend to access web api as user
+   1. Open app registration for web app frontend
+
+   2. Go to *API Permissions*
+
+   3. Click *Add a permission*
+
+   4. Select the tab *My APIs*
+
+   5. Chooise the app registration representing the web api backend
+
+   6. Select permissions `access_as_user`
+
+   7. Click *Add permissions*
+
+5. Update frontend web app configuration
+   1. Open *.env* file
+
+   2. Set the value of `REACT_APP_AAD_API_SCOPE` to your application ID URI
+
+6. Update backend web api configuration
+   1. Open *appsettings.json*
+
+   2. Set the value of `Authorization:AzureAd:Audience` to your application ID URI
+
 # Troubleshooting
 
 ## 1. Unable to load chats. Details: interaction_in_progress: Interaction is currently in progress. 

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -79,6 +79,7 @@
       "Instance": "https://login.microsoftonline.com/",
       "TenantId": "",
       "ClientId": "",
+      "Audience": "",
       "Scopes": "access_as_user" // Scopes that the client app requires to access the API
     }
   },

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -3,6 +3,9 @@
 REACT_APP_BACKEND_URI=https://localhost:40443/
 REACT_APP_AAD_AUTHORITY=https://login.microsoftonline.com/common
 REACT_APP_AAD_CLIENT_ID=
+# Authorization scopes to access webapi when using Azure AD authorization
+# example: api://12341234-1234-1234-1234-123412341234/access_as_user
+REACT_APP_AAD_API_SCOPE=
 
 # Optional Variables
 REACT_APP_SK_API_KEY=

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -3,12 +3,13 @@
 REACT_APP_BACKEND_URI=https://localhost:40443/
 REACT_APP_AAD_AUTHORITY=https://login.microsoftonline.com/common
 REACT_APP_AAD_CLIENT_ID=
-# Authorization scopes to access webapi when using Azure AD authorization
-# example: api://12341234-1234-1234-1234-123412341234/access_as_user
-REACT_APP_AAD_API_SCOPE=
 
 # Optional Variables
 REACT_APP_SK_API_KEY=
+
+# Authorization scopes to access webapi when using Azure AD authorization.
+# See paragraph "(Optional) Enable backend authorization via Azure AD" in README.md for details and setup
+REACT_APP_AAD_API_SCOPE=
 
 # To enable HTTPS, uncomment the following variables
 # HTTPS="true"

--- a/webapp/src/Constants.ts
+++ b/webapp/src/Constants.ts
@@ -15,7 +15,8 @@ export const Constants = {
             cacheLocation: 'localStorage',
             storeAuthStateInCookie: false,
         },
-        semanticKernelScopes: ['openid', 'offline_access', 'profile'],
+        semanticKernelScopes: ['openid', 'offline_access', 'profile']
+            .concat(process.env.REACT_APP_AAD_API_SCOPE as string ? [process.env.REACT_APP_AAD_API_SCOPE as string] : []),
         // MS Graph scopes required for loading user information
         msGraphAppScopes: ['User.ReadBasic.All'],
     },


### PR DESCRIPTION
### Motivation and Context

I want to authorize the calls from web app to web api via Azure AD (Entra ID). The application is prepared to use this feature but it's not fully implemented.  

This PR adds the required changes in the web app and the web api projects. It also contains configuration instructions.  
It resolves the issue #38 .

### Description

- adds `REACT_APP_AAD_API_SCOPE` to `Constants.ts` to request `access_as_user` scope via MSAL
- extends .env.example with the new introduced `REACT_APP_AAD_API_SCOPE` variable
- adds `Authorization:AzureAd:Audience` key to web api for request authorization checks
- adds a configuration instruction to `README.md`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
