### PR TITLE
Add "PR: ready for review" to all PRs when they are first created

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,6 +6,10 @@ webapp:
 webapi:
   - webapi/**/*
 
+# Add 'dependencies' label to any change of the 'webapp/yarn.lock' file
+dependencies:
+  - webapp/yarn.lock
+
 # Add 'deployment' label to any change within the 'deploy' directory
 deployment:
   - deploy/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,8 +12,12 @@ deployment:
 
 # Add 'documentation' label to any change of '.md' files
 documentation:
-  - '**/*.md'
+  - "**/*.md"
 
 # Add 'github actions' label to any change within the '.github/workflows' directory
-'github actions':
+"github actions":
   - .github/workflows/**/*
+
+# Add 'PR: ready for review' label to all PRs
+"PR: ready for review":
+  - "**"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -18,4 +18,5 @@ jobs:
     steps:
       - uses: actions/labeler@v4
         with:
+          dot: true # allows for easier matching of paths
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
adds the label to PRs that are newly created so that we don't have to.
also adds the 'dependencies' label to any change of the `yarn.lock` file

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
