### PR TITLE
Resolve CodeQL alerts by sanitizing route input

### DIFF
--- a/webapi/CopilotChat/Controllers/ChatMemoryController.cs
+++ b/webapi/CopilotChat/Controllers/ChatMemoryController.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -61,14 +62,14 @@ public class ChatMemoryController : ControllerBase
         // Make sure the chat session exists.
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId, v => _ = v))
         {
-            this._logger.LogWarning("Chat session: {0} does not exist.", chatId);
+            this._logger.LogWarning("Chat session: {0} does not exist.", this.SanitizeLogInput(chatId));
             return this.BadRequest($"Chat session: {chatId} does not exist.");
         }
 
         // Make sure the memory name is valid.
         if (!this.ValidateMemoryName(memoryName))
         {
-            this._logger.LogWarning("Memory name: {0} is invalid.", memoryName);
+            this._logger.LogWarning("Memory name: {0} is invalid.", this.SanitizeLogInput(memoryName));
             return this.BadRequest($"Memory name: {memoryName} is invalid.");
         }
 
@@ -100,6 +101,20 @@ public class ChatMemoryController : ControllerBase
     private bool ValidateMemoryName(string memoryName)
     {
         return this._promptOptions.MemoryMap.ContainsKey(memoryName);
+    }
+
+    /// <summary>
+    /// Sanitizes the log input by removing new line characters. 
+    /// This helps prevent log forgery attacks from malicious text.
+    /// </summary>
+    /// <remarks>
+    /// https://github.com/microsoft/chat-copilot/security/code-scanning/1
+    /// </remarks>
+    /// <param name="input">The input to sanitize.</param>
+    /// <returns>The sanitized input.</returns>
+    private string SanitizeLogInput(string input)
+    {
+        return input.Replace(Environment.NewLine, "");
     }
 
     # endregion


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
logging fields that can be passed by the user (e.g. route params) is flagged as a High sev issue by CodeQL:
https://github.com/microsoft/chat-copilot/security/code-scanning/1

### Description
suggested fix is to remove new line characters from the input.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
