### PR TITLE
Let chatSession/create return the full chatSession object

### DIFF
--- a/webapi/CopilotChat/Models/CreateChatResponse.cs
+++ b/webapi/CopilotChat/Models/CreateChatResponse.cs
@@ -6,7 +6,7 @@ namespace SemanticKernel.Service.CopilotChat.Models;
 
 /// <summary>
 /// Response object definition to the 'chatSession/create' request.
-/// This group the initial bot message with the chat session
+/// This groups the initial bot message with the chat session
 /// to avoid making two requests.
 /// </summary>
 public class CreateChatResponse

--- a/webapi/CopilotChat/Models/CreateChatResponse.cs
+++ b/webapi/CopilotChat/Models/CreateChatResponse.cs
@@ -5,32 +5,27 @@ using System.Text.Json.Serialization;
 namespace SemanticKernel.Service.CopilotChat.Models;
 
 /// <summary>
-/// Response to chatSession/create request.
+/// Response object definition to the 'chatSession/create' request.
+/// This group the initial bot message with the chat session
+/// to avoid making two requests.
 /// </summary>
 public class CreateChatResponse
 {
     /// <summary>
-    /// ID that is persistent and unique to new chat session.
+    /// The chat session that was created.
     /// </summary>
-    [JsonPropertyName("id")]
-    public string Id { get; set; }
-
-    /// <summary>
-    /// Title of the chat.
-    /// </summary>
-    [JsonPropertyName("title")]
-    public string Title { get; set; }
+    [JsonPropertyName("chatSession")]
+    public ChatSession ChatSession { get; set; }
 
     /// <summary>
     /// Initial bot message.
     /// </summary>
     [JsonPropertyName("initialBotMessage")]
-    public ChatMessage? InitialBotMessage { get; set; }
+    public ChatMessage InitialBotMessage { get; set; }
 
     public CreateChatResponse(ChatSession chatSession, ChatMessage initialBotMessage)
     {
-        this.Id = chatSession.Id;
-        this.Title = chatSession.Title;
+        this.ChatSession = chatSession;
         this.InitialBotMessage = initialBotMessage;
     }
 }

--- a/webapp/src/components/chat/persona/PromptEditor.tsx
+++ b/webapp/src/components/chat/persona/PromptEditor.tsx
@@ -103,7 +103,9 @@ export const PromptEditor: React.FC<PromptEditorProps> = ({
             />
             {isEditable && (
                 <div className={classes.controls}>
-                    <Button onClick={onSaveButtonClick}>Save</Button>
+                    <Button onClick={onSaveButtonClick} disabled={value.length <= 0 || value === prompt}>
+                        Save
+                    </Button>
                 </div>
             )}
         </div>

--- a/webapp/src/components/chat/tabs/PersonaTab.tsx
+++ b/webapp/src/components/chat/tabs/PersonaTab.tsx
@@ -20,18 +20,14 @@ export const PersonaTab: React.FC = () => {
     const [longTermMemory, setLongTermMemory] = React.useState<string>('');
 
     React.useEffect(() => {
-        chat.getSemanticMemories(selectedId, 'WorkingMemory')
-            .then((memories) => {
+        void Promise.all([
+            chat.getSemanticMemories(selectedId, 'WorkingMemory').then((memories) => {
                 setShortTermMemory(memories.join('\n'));
-            })
-            .catch(() => {});
-
-        chat.getSemanticMemories(selectedId, 'LongTermMemory')
-            .then((memories) => {
+            }),
+            chat.getSemanticMemories(selectedId, 'LongTermMemory').then((memories) => {
                 setLongTermMemory(memories.join('\n'));
-            })
-            .catch(() => {});
-
+            }),
+        ]);
         // We don't want to have chat as one of the dependencies as it will cause infinite loop.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedId]);

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -17,8 +17,8 @@ import { Plugin } from '../../redux/features/plugins/PluginsState';
 import { AuthHelper } from '../auth/AuthHelper';
 import { AlertType } from '../models/AlertType';
 import { Bot } from '../models/Bot';
-import { ChatMessageType, IChatMessage } from '../models/ChatMessage';
-import { IChatSession } from '../models/ChatSession';
+import { ChatMessageType } from '../models/ChatMessage';
+import { IChatSession, ICreateChatSessionResponse } from '../models/ChatSession';
 import { IChatUser } from '../models/ChatUser';
 import { TokenUsage } from '../models/TokenUsage';
 import { IAskVariables } from '../semantic-kernel/model/Ask';
@@ -74,23 +74,25 @@ export const useChat = () => {
         const chatTitle = `Copilot @ ${new Date().toLocaleString()}`;
         const accessToken = await AuthHelper.getSKaaSAccessToken(instance, inProgress);
         try {
-            await chatService.createChatAsync(userId, chatTitle, accessToken).then((result: IChatSession) => {
-                const newChat: ChatState = {
-                    id: result.id,
-                    title: result.title,
-                    systemDescription: result.systemDescription,
-                    memoryBalance: result.memoryBalance,
-                    messages: [result.initialBotMessage as IChatMessage],
-                    users: [loggedInUser],
-                    botProfilePicture: getBotProfilePicture(Object.keys(conversations).length),
-                    input: '',
-                    botResponseStatus: undefined,
-                    userDataLoaded: false,
-                };
+            await chatService
+                .createChatAsync(userId, chatTitle, accessToken)
+                .then((result: ICreateChatSessionResponse) => {
+                    const newChat: ChatState = {
+                        id: result.chatSession.id,
+                        title: result.chatSession.title,
+                        systemDescription: result.chatSession.systemDescription,
+                        memoryBalance: result.chatSession.memoryBalance,
+                        messages: [result.initialBotMessage],
+                        users: [loggedInUser],
+                        botProfilePicture: getBotProfilePicture(Object.keys(conversations).length),
+                        input: '',
+                        botResponseStatus: undefined,
+                        userDataLoaded: false,
+                    };
 
-                dispatch(addConversation(newChat));
-                return newChat.id;
-            });
+                    dispatch(addConversation(newChat));
+                    return newChat.id;
+                });
         } catch (e: any) {
             const errorMessage = `Unable to create new chat. Details: ${getErrorDetails(e)}`;
             dispatch(addAlert({ message: errorMessage, type: AlertType.Error }));

--- a/webapp/src/libs/models/ChatSession.ts
+++ b/webapp/src/libs/models/ChatSession.ts
@@ -5,7 +5,11 @@ import { IChatMessage } from './ChatMessage';
 export interface IChatSession {
     id: string;
     title: string;
-    initialBotMessage?: IChatMessage;
     systemDescription: string;
     memoryBalance: number;
+}
+
+export interface ICreateChatSessionResponse {
+    chatSession: IChatSession;
+    initialBotMessage: IChatMessage;
 }

--- a/webapp/src/libs/services/ChatService.ts
+++ b/webapp/src/libs/services/ChatService.ts
@@ -4,7 +4,7 @@ import { Plugin } from '../../redux/features/plugins/PluginsState';
 import { ChatMemorySource } from '../models/ChatMemorySource';
 import { IChatMessage } from '../models/ChatMessage';
 import { IChatParticipant } from '../models/ChatParticipant';
-import { IChatSession } from '../models/ChatSession';
+import { IChatSession, ICreateChatSessionResponse } from '../models/ChatSession';
 import { IChatUser } from '../models/ChatUser';
 import { IAsk, IAskVariables } from '../semantic-kernel/model/Ask';
 import { IAskResult } from '../semantic-kernel/model/AskResult';
@@ -12,13 +12,17 @@ import { ICustomPlugin } from '../semantic-kernel/model/CustomPlugin';
 import { BaseService } from './BaseService';
 
 export class ChatService extends BaseService {
-    public createChatAsync = async (userId: string, title: string, accessToken: string): Promise<IChatSession> => {
+    public createChatAsync = async (
+        userId: string,
+        title: string,
+        accessToken: string,
+    ): Promise<ICreateChatSessionResponse> => {
         const body = {
             userId,
             title,
         };
 
-        const result = await this.getResponseAsync<IChatSession>(
+        const result = await this.getResponseAsync<ICreateChatSessionResponse>(
             {
                 commandPath: 'chatSession/create',
                 method: 'POST',
@@ -77,7 +81,7 @@ export class ChatService extends BaseService {
         title: string,
         systemDescription: string,
         memoryBalance: number,
-        accessToken: string
+        accessToken: string,
     ): Promise<any> => {
         const body: IChatSession = {
             id: chatId,
@@ -217,7 +221,11 @@ export class ChatService extends BaseService {
         return chatUsers;
     };
 
-    public getSemanticMemoriesAsync = async (chatId: string, memoryName: string, accessToken: string): Promise<string[]> => {
+    public getSemanticMemoriesAsync = async (
+        chatId: string,
+        memoryName: string,
+        accessToken: string,
+    ): Promise<string[]> => {
         const result = await this.getResponseAsync<string[]>(
             {
                 commandPath: `chatMemory/${chatId}/${memoryName}`,
@@ -227,5 +235,5 @@ export class ChatService extends BaseService {
         );
 
         return result;
-    }
+    };
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The API chatSession/create was not returning the full chatSession object, which caused issues where the webapp was not able to get some properties from the new chat session.

### Description
Return the full chatSession object along with the initial chat message.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
