### PR TITLE
Added support for setting Web App region in deployment - Fixes #17

### DIFF
--- a/deploy/deploy-azure.ps1
+++ b/deploy/deploy-azure.ps1
@@ -37,6 +37,10 @@ param(
     $Region = "southcentralus",
 
     [string]
+    # Region to deploy to the static web app into. This must be a region that supports static web apps.
+    $WebAppRegion = "westus2",
+
+    [string]
     # SKU for the Azure App Service plan
     $WebAppServiceSku = "B1",
 
@@ -86,6 +90,7 @@ if ($AIService -eq "OpenAI" -and !$AIApiKey) {
 $jsonConfig = "
 {
     `\`"webAppServiceSku`\`": { `\`"value`\`": `\`"$WebAppServiceSku`\`" },
+    `\`"webappLocation`\`": { `\`"value`\`": `\`"$WebAppRegion`\`" },
     `\`"aiService`\`": { `\`"value`\`": `\`"$AIService`\`" },
     `\`"aiApiKey`\`": { `\`"value`\`": `\`"$AIApiKey`\`" },
     `\`"aiEndpoint`\`": { `\`"value`\`": `\`"$AIEndpoint`\`" },

--- a/deploy/deploy-azure.sh
+++ b/deploy/deploy-azure.sh
@@ -16,6 +16,7 @@ usage() {
     echo "  -aiend, --ai-endpoint AI_ENDPOINT          Endpoint for existing Azure OpenAI resource"
     echo "  -rg, --resource-group RESOURCE_GROUP       Resource group to which to make the deployment (default: \"rg-\$DEPLOYMENT_NAME\")"
     echo "  -r, --region REGION                        Region to which to make the deployment (default: \"South Central US\")"
+    echo "  -wr, --web-app-region WEB_APP_REGION       Region to deploy to the static web app into. This must be a region that supports static web apps. (default: \"West US 2\")"
     echo "  -a, --app-service-sku WEB_APP_SVC_SKU      SKU for the Azure App Service plan (default: \"B1\")"
     echo "  -ms, --memory-store                        Method to use to persist embeddings. Valid values are"
     echo "                                             \"AzureCognitiveSearch\" (default), \"Qdrant\" and \"Volatile\""
@@ -66,6 +67,11 @@ while [[ $# -gt 0 ]]; do
         ;;
         -r|--region)
         REGION="$2"
+        shift
+        shift
+        ;;
+        -wr|--web-app-region)
+        WEB_APP_REGION="$2"
         shift
         shift
         ;;
@@ -164,6 +170,7 @@ az account set -s "$SUBSCRIPTION"
 # Set defaults
 : "${REGION:="southcentralus"}"
 : "${WEB_APP_SVC_SKU:="B1"}"
+: "${WEB_APP_REGION:="westus2"}"
 : "${MEMORY_STORE:="AzureCognitiveSearch"}"
 : "${NO_COSMOS_DB:=false}"
 : "${NO_SPEECH_SERVICES:=false}"
@@ -173,6 +180,7 @@ JSON_CONFIG=$(cat << EOF
 {
     "webApiKey": { "value" : "$WEB_API_KEY" },
     "webAppServiceSku": { "value": "$WEB_APP_SVC_SKU" },
+    "webappLocation": { "value": "$WEB_APP_REGION" },
     "aiService": { "value": "$AI_SERVICE_TYPE" },
     "aiApiKey": { "value": "$AI_SERVICE_KEY" },
     "deployWebApiPackage": { "value": $([ "$NO_DEPLOY_PACKAGE" = true ] && echo "false" || echo "true") },


### PR DESCRIPTION
### Motivation and Context

Add ability to set Web App region in deployment - Fixes #17
 
### Description

This PR adds support to the `deploy-azure.ps1` and `deploy-azure.sh` files to pass through the region to deploy the Static Web App to. This will default to `westus2 and is set in the .PS1/SH files.

This enables deploying all the resources to the same region, even though Static Web Apps is supported in only a few regions. The one region that all resource types are supported in is WestEurope.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

Tests:
`azure-deploy.ps1`
<img width="845" alt="image" src="https://github.com/microsoft/chat-copilot/assets/7589164/dfc1412a-0d7c-4045-adc8-c07f0202adc2">

<img width="944" alt="image" src="https://github.com/microsoft/chat-copilot/assets/7589164/d6af1409-892a-44b4-a3c0-18783ae2170e">

`azure-deploy.sh`
<img width="1110" alt="image" src="https://github.com/microsoft/chat-copilot/assets/7589164/4ef5abd8-6d33-4386-8254-b87af5f99aae">

<img width="969" alt="image" src="https://github.com/microsoft/chat-copilot/assets/7589164/5291a3dc-6dd3-4fc2-87ea-0da8f143cd37">
