### PR TITLE
Update Readme with note on execution policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You will need the following items to run the sample:
      -CompletionModel {DEPLOYMENT_NAME} -EmbeddingModel {DEPLOYMENT_NAME} -PlannerModel {DEPLOYMENT_NAME}
      ```
 
-3. Run Chat Copilot locally. This step starts both the backend API and frontend application.
+4. Run Chat Copilot locally. This step starts both the backend API and frontend application.
 
    ```powershell
    .\Start.ps1

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ You will need the following items to run the sample:
 1. Open PowerShell as an administrator.
 2. Setup your environment.
 
-   ```powershell
-   cd <path to chat-copilot>\scripts\
-   .\Install.ps1
-   ```
+    ```powershell
+    cd <path to chat-copilot>\scripts\
+    .\Install.ps1
+    ```
 
-   > NOTE: This script will install `Chocolatey`, `dotnet-7.0-sdk`, `nodejs`, and `yarn`.
+    > NOTE: This script will install `Chocolatey`, `dotnet-7.0-sdk`, `nodejs`, and `yarn`.
+     
+    > NOTE: If you receive an error that the script is not digitally signed or cannot execute on the system, you may need to [change the execution policy](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.3#change-the-execution-policy) (see list of [policies](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.3#powershell-execution-policies) and [scopes](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.3#execution-policy-scope)) or [unblock the script](https://learn.microsoft.com/powershell/module/microsoft.powershell.security/get-executionpolicy?view=powershell-7.3#example-4-unblock-a-script-to-run-it-without-changing-the-execution-policy).
 
 3. Configure Chat Copilot.
 
@@ -70,7 +72,7 @@ You will need the following items to run the sample:
      -CompletionModel {DEPLOYMENT_NAME} -EmbeddingModel {DEPLOYMENT_NAME} -PlannerModel {DEPLOYMENT_NAME}
      ```
 
-4. Run Chat Copilot locally. This step starts both the backend API and frontend application.
+3. Run Chat Copilot locally. This step starts both the backend API and frontend application.
 
    ```powershell
    .\Start.ps1


### PR DESCRIPTION
### Motivation and Context

A user has been unable to run the primary Readme ps scripts (e.g., scripts\Install.ps1) due to the error:
"File <ps script> cannot be loaded. The file <ps script> is not digitally signed. You cannot run this script on the current system. For more information about running scripts and setting execution policy, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170."

### Description

Adds note directing user to official documentation pages on changing execution policy or unblocking the script.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
