### PR TITLE
Hack Github action: no reusable workflow

### DIFF
--- a/.github/workflows/copilot-deploy-pipeline.yml
+++ b/.github/workflows/copilot-deploy-pipeline.yml
@@ -15,7 +15,56 @@ permissions:
 
 jobs:
   build:
-    uses: ./.github/workflows/copilot-build-backend.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { dotnet: "6.0", configuration: Release, os: windows-latest }
+
+    runs-on: ${{ matrix.os }}
+
+    environment: feature-semantic-memory
+
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
+
+    outputs:
+      artifact: ${{steps.artifactoutput.outputs.artifactname}}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          clean: true
+
+      - name: Add custom nuget source
+        run: |
+          dotnet nuget add source "https://pkgs.dev.azure.com/msctoproj/Lightspeed/_packaging/SemanticMemoryPrivate/nuget/v3/index.json" --username az --password ${{ secrets.AZURE_DEVOPS_PAT }} --name SemanticMemoryPrivate --store-password-in-clear-text
+
+      - name: Package Copilot Chat WebAPI
+        run: |
+          scripts\deploy\package-webapi.ps1 -Configuration Release -DotnetFramework net6.0 -TargetRuntime win-x64 -OutputDirectory ${{ github.workspace }}\scripts\deploy
+
+      - name: Check formatting of Copilot Chat WebAPI
+        run: |
+          cd webapi/
+          dotnet format --verify-no-changes --verbosity diagnostic
+
+      - name: Set version tag
+        id: versiontag
+        run: |
+          $VERSION_TAG="$(Get-Date -Format "MMddHHmmss")"
+          echo $VERSION_TAG
+          Write-Output "versiontag=$VERSION_TAG" >> $env:GITHUB_OUTPUT
+
+      - name: Upload package to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: copilotchat-webapi-${{ steps.versiontag.outputs.versiontag }}
+          path: ${{ github.workspace }}\scripts\deploy\out\webapi.zip
+
+      - name: "Set outputs"
+        id: artifactoutput
+        run: Write-Output "artifactname=copilotchat-webapi-${{ steps.versiontag.outputs.versiontag }}" >> $env:GITHUB_OUTPUT
 
   feature-semantic-memory:
     needs: build


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Problem: when using the reusable workflow "copilot-build-backend.yml" from "copilot-deploy-pipeline.yml", the environment secrets do not propagate. 

### Description

Hack: copied the build workflow directly to the deploy workflow. This will create code duplication but will allow the deployment workflow to pass. This will get remove once we have the public Semantic Memory packages.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
