### PR TITLE
Add postgresql memory store

### DIFF
--- a/scripts/deploy/deploy-azure.ps1
+++ b/scripts/deploy/deploy-azure.ps1
@@ -44,10 +44,14 @@ param(
     # SKU for the Azure App Service plan
     $WebAppServiceSku = "B1",
 
-    [ValidateSet("Volatile", "AzureCognitiveSearch", "Qdrant")]
+    [ValidateSet("Volatile", "AzureCognitiveSearch", "Qdrant", "Postgres")]
     [string]
     # What method to use to persist embeddings
     $MemoryStore = "AzureCognitiveSearch",
+
+    [SecureString]
+    # Password for the Postgres database
+    $SqlAdminPassword = '',
 
     [switch]
     # Don't deploy Cosmos DB for chat storage - Use volatile memory instead
@@ -87,6 +91,10 @@ if ($AIService -eq "OpenAI" -and !$AIApiKey) {
     exit 1
 }
 
+if ($MemoryStore -eq "Postgres" -and !$SqlAdminPassword) {
+    exit 1
+}
+
 $jsonConfig = "
 {
     `\`"webAppServiceSku`\`": { `\`"value`\`": `\`"$WebAppServiceSku`\`" },
@@ -97,7 +105,8 @@ $jsonConfig = "
     `\`"deployNewAzureOpenAI`\`": { `\`"value`\`": $(If ($DeployAzureOpenAI) {"true"} Else {"false"}) },
     `\`"memoryStore`\`": { `\`"value`\`": `\`"$MemoryStore`\`" },
     `\`"deployCosmosDB`\`": { `\`"value`\`": $(If (!($NoCosmosDb)) {"true"} Else {"false"}) },
-    `\`"deploySpeechServices`\`": { `\`"value`\`": $(If (!($NoSpeechServices)) {"true"} Else {"false"}) }
+    `\`"deploySpeechServices`\`": { `\`"value`\`": $(If (!($NoSpeechServices)) {"true"} Else {"false"}) },
+    `\`"sqlAdminPassword`\`": { `\`"value`\`": `\`"$(ConvertFrom-SecureString $SqlAdminPassword -AsPlainText)`\`" }
 }
 "
 

--- a/scripts/deploy/deploy-azure.ps1
+++ b/scripts/deploy/deploy-azure.ps1
@@ -92,6 +92,7 @@ if ($AIService -eq "OpenAI" -and !$AIApiKey) {
 }
 
 if ($MemoryStore -eq "Postgres" -and !$SqlAdminPassword) {
+    Write-Host "When MemoryStore is Postgres, SqlAdminPassword must be set"
     exit 1
 }
 

--- a/scripts/deploy/deploy-azure.ps1
+++ b/scripts/deploy/deploy-azure.ps1
@@ -51,7 +51,7 @@ param(
 
     [SecureString]
     # Password for the Postgres database
-    $SqlAdminPassword = '',
+    $SqlAdminPassword = "",
 
     [switch]
     # Don't deploy Cosmos DB for chat storage - Use volatile memory instead

--- a/scripts/deploy/main.json
+++ b/scripts/deploy/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.20.4.51522",
-      "templateHash": "15530074115758293206"
+      "templateHash": "1330294935556235998"
     }
   },
   "parameters": {
@@ -113,7 +113,8 @@
       "allowedValues": [
         "Volatile",
         "AzureCognitiveSearch",
-        "Qdrant"
+        "Qdrant",
+        "Postgres"
       ],
       "metadata": {
         "description": "What method to use to persist embeddings"
@@ -145,6 +146,13 @@
       "defaultValue": "westus2",
       "metadata": {
         "description": "Region for the webapp frontend"
+      }
+    },
+    "sqlAdminPassword": {
+      "type": "securestring",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "PostgreSQL admin password"
       }
     }
   },
@@ -360,6 +368,10 @@
             "value": "[if(equals(parameters('memoryStore'), 'AzureCognitiveSearch'), listAdminKeys(resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName'))), '2022-09-01').primaryKey, '')]"
           },
           {
+            "name": "MemoryStore:Postgres:ConnectionString",
+            "value": "[if(equals(parameters('memoryStore'), 'Postgres'), format('Host={0}:5432;Username=citus;Password={1};Database=citus', reference(resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName'))), '2022-11-08').serverNames[0].fullyQualifiedDomainName, parameters('sqlAdminPassword')), '')]"
+          },
+          {
             "name": "AzureSpeech:Region",
             "value": "[parameters('location')]"
           },
@@ -416,6 +428,7 @@
         "[resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.DocumentDB/databaseAccounts', toLower(format('cosmos-{0}', variables('uniqueName'))))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName')))]",
+        "[resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('cog-{0}', variables('uniqueName')))]"
       ]
     },
@@ -633,6 +646,16 @@
                   }
                 }
               ],
+              "privateEndpointNetworkPolicies": "Disabled",
+              "privateLinkServiceNetworkPolicies": "Enabled"
+            }
+          },
+          {
+            "name": "postgresSubnet",
+            "properties": {
+              "addressPrefix": "10.0.3.0/24",
+              "serviceEndpoints": [],
+              "delegations": [],
               "privateEndpointNetworkPolicies": "Disabled",
               "privateLinkServiceNetworkPolicies": "Enabled"
             }
@@ -876,6 +899,96 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', toLower(format('cosmos-{0}', variables('uniqueName'))), 'CopilotChat')]"
+      ]
+    },
+    {
+      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
+      "type": "Microsoft.DBforPostgreSQL/serverGroupsv2",
+      "apiVersion": "2022-11-08",
+      "name": "[format('pg-{0}', variables('uniqueName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "postgresqlVersion": "15",
+        "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
+        "enableHa": false,
+        "coordinatorVCores": 1,
+        "coordinatorServerEdition": "BurstableMemoryOptimized",
+        "coordinatorStorageQuotaInMb": 32768,
+        "nodeVCores": 4,
+        "nodeCount": 0,
+        "nodeStorageQuotaInMb": 524288,
+        "nodeEnablePublicIpAccess": false
+      }
+    },
+    {
+      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2020-06-01",
+      "name": "privatelink.postgres.cosmos.azure.com",
+      "location": "global"
+    },
+    {
+      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
+      "type": "Microsoft.Network/privateEndpoints",
+      "apiVersion": "2023-04-01",
+      "name": "[format('pg-{0}-pe', variables('uniqueName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "subnet": {
+          "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[2].id]"
+        },
+        "privateLinkServiceConnections": [
+          {
+            "name": "postgres",
+            "properties": {
+              "privateLinkServiceId": "[resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName')))]",
+              "groupIds": [
+                "coordinator"
+              ]
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName')))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName')))]"
+      ]
+    },
+    {
+      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', 'privatelink.postgres.cosmos.azure.com', format('pg-{0}-vnl', variables('uniqueName')))]",
+      "location": "global",
+      "properties": {
+        "virtualNetwork": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName')))]"
+        },
+        "registrationEnabled": true
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.cosmos.azure.com')]",
+        "[resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName')))]"
+      ]
+    },
+    {
+      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2023-04-01",
+      "name": "[format('{0}/default', format('pg-{0}-pe', variables('uniqueName')))]",
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "postgres",
+            "properties": {
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.cosmos.azure.com')]"
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.cosmos.azure.com')]",
+        "[resourceId('Microsoft.Network/privateEndpoints', format('pg-{0}-pe', variables('uniqueName')))]"
       ]
     },
     {

--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -13,13 +13,22 @@
     <PackageReference Include="Azure.AI.FormRecognizer" Version="4.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.2" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Planning.StepwisePlanner" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Chroma" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Skills.MsGraph" Version="0.19.230804.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Skills.OpenAPI" Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Planning.StepwisePlanner"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Chroma"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Postgres"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Skills.MsGraph"
+      Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Skills.OpenAPI"
+      Version="0.19.230804.2-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Skills.Web" Version="0.19.230804.2-preview" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/webapi/Extensions/SemanticKernelExtensions.cs
+++ b/webapi/Extensions/SemanticKernelExtensions.cs
@@ -17,11 +17,14 @@ using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
 using Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch;
 using Microsoft.SemanticKernel.Connectors.Memory.Chroma;
+using Microsoft.SemanticKernel.Connectors.Memory.Postgres;
 using Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Skills.Core;
 using Microsoft.SemanticKernel.TemplateEngine;
+using Npgsql;
+using Pgvector.Npgsql;
 using static CopilotChat.WebApi.Options.MemoryStoreOptions;
 
 namespace CopilotChat.WebApi.Extensions;
@@ -219,6 +222,24 @@ internal static class SemanticKernelExtensions
                         logger: sp.GetRequiredService<ILogger<IChromaClient>>()
                     );
                 });
+                break;
+            case MemoryStoreOptions.MemoryStoreType.Postgres:
+                if (config.Postgres == null)
+                {
+                    throw new InvalidOperationException("MemoryStore type is Cosmos and Cosmos configuration is null.");
+                }
+
+                var dataSourceBuilder = new NpgsqlDataSourceBuilder(config.Postgres.ConnectionString);
+                dataSourceBuilder.UseVector();
+
+                services.AddSingleton<IMemoryStore>(sp =>
+                {
+                    return new PostgresMemoryStore(
+                        dataSource: dataSourceBuilder.Build(),
+                        vectorSize: config.Postgres.VectorSize
+                    );
+                });
+
                 break;
 
             default:

--- a/webapi/Extensions/SemanticKernelExtensions.cs
+++ b/webapi/Extensions/SemanticKernelExtensions.cs
@@ -223,6 +223,7 @@ internal static class SemanticKernelExtensions
                     );
                 });
                 break;
+
             case MemoryStoreOptions.MemoryStoreType.Postgres:
                 if (config.Postgres == null)
                 {

--- a/webapi/Options/MemoryStoreOptions.cs
+++ b/webapi/Options/MemoryStoreOptions.cs
@@ -32,7 +32,12 @@ public class MemoryStoreOptions
         /// <summary>
         /// Chroma DB persistent memory store.
         /// </summary>
-        Chroma
+        Chroma,
+
+        /// <summary>
+        /// Cosmos DB persistent memory store.
+        /// </summary>
+        Postgres,
     }
 
     /// <summary>
@@ -57,4 +62,10 @@ public class MemoryStoreOptions
     /// </summary>
     [RequiredOnPropertyValue(nameof(Type), MemoryStoreType.AzureCognitiveSearch)]
     public AzureCognitiveSearchOptions? AzureCognitiveSearch { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration for the Cosmos memory store.
+    /// </summary>
+    [RequiredOnPropertyValue(nameof(Type), MemoryStoreType.Postgres)]
+    public PostgresOptions? Postgres { get; set; }
 }

--- a/webapi/Options/PostgresOptions.cs
+++ b/webapi/Options/PostgresOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace CopilotChat.WebApi.Options;
+
+/// <summary>
+/// Configuration settings for connecting to Postgres.
+/// </summary>
+public class PostgresOptions
+{
+    /// <summary>
+    /// Gets or sets the Postgres connection string.
+    /// </summary>
+    [Required, NotEmptyOrWhitespace]
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the vector size.
+    /// </summary>
+    [Required, Range(1, int.MaxValue)]
+    public int VectorSize { get; set; }
+}

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -23,7 +23,7 @@
   // Default AI service configuration for generating AI responses and embeddings from the user's input.
   // https://platform.openai.com/docs/guides/chat
   // To use Azure OpenAI as the AI completion service:
-  // - Set "Type" to "AzureOpenAI" 
+  // - Set "Type" to "AzureOpenAI"
   // - Set "Endpoint" to the endpoint of your Azure OpenAI instance (e.g., "https://contoso.openai.azure.com")
   // - Set "Key" using dotnet's user secrets (see above)
   //     (i.e. dotnet user-secrets set "AIService:Key" "MY_AZURE_OPENAI_KEY")
@@ -53,12 +53,12 @@
   // - Set Planner:Type to "Sequential" to enable the multi-step SequentialPlanner
   //     Note: SequentialPlanner works best with `gpt-4`. See the "Enabling Sequential Planner" section in webapi/README.md for configuration instructions.
   // - Set Planner:Type to "Stepwise" to enable MRKL style planning
-  // - Set Planner:RelevancyThreshold to a decimal between 0 and 1.0. 
+  // - Set Planner:RelevancyThreshold to a decimal between 0 and 1.0.
   //
   "Planner": {
     "Type": "Sequential",
     // The minimum relevancy score for a function to be considered.
-    // Set RelevancyThreshold to a value between 0 and 1 if using the SequentialPlanner or Stepwise planner with gpt-3.5-turbo. 
+    // Set RelevancyThreshold to a value between 0 and 1 if using the SequentialPlanner or Stepwise planner with gpt-3.5-turbo.
     // Ignored when Planner:Type is "Action"
     "RelevancyThreshold": "0.25",
     // Whether to allow missing functions in the plan on creation then sanitize output. Functions are considered missing if they're not available in the planner's kernel's context.
@@ -125,12 +125,14 @@
   },
   //
   // Memory stores are used for storing new memories and retrieving semantically similar memories.
-  // - Supported Types are "volatile", "qdrant", "azurecognitivesearch", or "chroma".
+  // - Supported Types are "volatile", "qdrant", "azurecognitivesearch", "postgres", or "chroma".
   // - When using Qdrant or Azure Cognitive Search, see ./README.md for deployment instructions.
   // - Set "MemoryStore:AzureCognitiveSearch:Key" using dotnet's user secrets (see above)
   //     (i.e. dotnet user-secrets set "MemoryStore:AzureCognitiveSearch:Key" "MY_AZCOGSRCH_KEY")
   // - Set "MemoryStore:Qdrant:Key" using dotnet's user secrets (see above) if you are using a Qdrant Cloud instance.
   //     (i.e. dotnet user-secrets set "MemoryStore:Qdrant:Key" "MY_QDRANTCLOUD_KEY")
+  // - Set "MemoryStore:Postgres:ConnectionString" using dotnet's user secrets (see above) if you are using a PostgreSQL database (or CosmosDB for PostgreSQL instance).
+  //     (i.e. dotnet user-secrets set "MemoryStore:Postgres:ConnectionString" "MY_POSTGRES_CONNECTION_STRING")
   //
   "MemoryStore": {
     "Type": "volatile",
@@ -147,6 +149,10 @@
     "Chroma": {
       "Host": "http://localhost",
       "Port": "8000"
+    },
+    "Postgres": {
+      "VectorSize": 1536
+      // "ConnectionString": // dotnet user-secrets set "MemoryStore:Postgres:ConnectionString" "MY_POSTGRES_CONNECTION_STRING"
     }
   },
   //
@@ -170,7 +176,7 @@
   // OCR support is used for allowing end users to upload images containing text in addition to text based documents.
   // - Supported Types are "none", "azureformrecognizer", "tesseract".
   // - When using Tesseract OCR Support (In order to upload image file formats such as png, jpg and tiff)
-  //  - Obtain language data files here: https://github.com/tesseract-ocr/tessdata . 
+  //  - Obtain language data files here: https://github.com/tesseract-ocr/tessdata .
   //  - Add these files to your `data` folder or the path specified in the "FilePath" property and set the "Copy to Output Directory" value to "Copy if newer".
   // - When using Azure Form Recognizer OCR Support
   //  - Set "OcrSupport:AzureFormRecognizer:Key" using dotnet's user secrets (see above)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  3. What problem does it solve?
  5. What scenario does it contribute to?
  7. If it fixes an open issue, please link to the issue here.
-->

I would like to provide a production-grade PaaS solution to store the vector database.
It provides PostgreSQL database support for memory. We can now use Azure Database for PostgreSQL or CosmosDB for PostgreSQL.

Fixes #166 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
I added configuration support for PostgreSQL. in the kernel initialization. 
Furthermore I updated the deployment script to support this configuration.

> Note: In the deployment scripts, I've added the SqlAdminPassword parameter, which must be supplied during provisioning. I intentionally named it without the PostgreSQL name, as I also worked on implementing SQL Server Memory store in the SK repository. This parameter could be used by both databases during deployment.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
> Not found test project on the API part ;(
- [x] I didn't break anyone :smile:
