### PR TITLE
Build webapi package and deploy Azure infrastructure in parallel

### DIFF
--- a/.github/workflows/copilot-build-backend.yml
+++ b/.github/workflows/copilot-build-backend.yml
@@ -1,6 +1,7 @@
 name: copilot-build-backend
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: ["main"]
     paths:

--- a/.github/workflows/copilot-deploy-binaries.yml
+++ b/.github/workflows/copilot-deploy-binaries.yml
@@ -1,4 +1,4 @@
-name: copilot-deploy-environment
+name: copilot-deploy-binaries
 
 on:
   workflow_call:
@@ -28,19 +28,7 @@ permissions:
   id-token: write
 
 jobs:
-  deploy-infra:
-    uses: ./.github/workflows/copilot-deploy-infra.yml
-    with:
-      ENVIRONMENT: ${{inputs.ENVIRONMENT}}
-    secrets:
-      AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
-      AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
-      AZURE_SUBSCRIPTION_ID: ${{secrets.AZURE_SUBSCRIPTION_ID}}
-      WEB_API_KEY: ${{secrets.WEB_API_KEY}}
-      AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
-
   deploy-backend:
-    needs: [deploy-infra]
     uses: ./.github/workflows/copilot-deploy-backend.yml
     with:
       ARTIFACT_NAME: ${{inputs.ARTIFACT_NAME}}
@@ -52,7 +40,6 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
   deploy-frontend:
-    needs: [deploy-infra]
     uses: ./.github/workflows/copilot-deploy-frontend.yml
     with:
       DEPLOYMENT_NAME: ${{needs.deploy-infra.outputs.deployment-id}}

--- a/.github/workflows/copilot-deploy-pipeline.yml
+++ b/.github/workflows/copilot-deploy-pipeline.yml
@@ -17,9 +17,20 @@ jobs:
   build:
     uses: ./.github/workflows/copilot-build-backend.yml
 
-  int:
-    needs: build
-    uses: ./.github/workflows/copilot-deploy-environment.yml
+  deploy-int-infra:
+    uses: ./.github/workflows/copilot-deploy-infra.yml
+    with:
+      ENVIRONMENT: int
+    secrets:
+      AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
+      AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
+      AZURE_SUBSCRIPTION_ID: ${{secrets.AZURE_SUBSCRIPTION_ID}}
+      WEB_API_KEY: ${{secrets.WEB_API_KEY}}
+      AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
+
+  deploy-int-binaries:
+    needs: [build, deploy-int-infra]
+    uses: ./.github/workflows/copilot-deploy-binaries.yml
     with:
       ENVIRONMENT: int
       ARTIFACT_NAME: ${{needs.build.outputs.artifact}}
@@ -31,9 +42,21 @@ jobs:
       AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
       APPLICATION_AUTHORITY: ${{secrets.APPLICATION_AUTHORITY}}
 
-  stable:
-    uses: ./.github/workflows/copilot-deploy-environment.yml
-    needs: [build, int]
+  deploy-stable-infra:
+    needs: deploy-int-binaries
+    uses: ./.github/workflows/copilot-deploy-infra.yml
+    with:
+      ENVIRONMENT: stable
+    secrets:
+      AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
+      AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
+      AZURE_SUBSCRIPTION_ID: ${{secrets.AZURE_SUBSCRIPTION_ID}}
+      WEB_API_KEY: ${{secrets.WEB_API_KEY}}
+      AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
+
+  deploy-stable-binaries:
+    uses: ./.github/workflows/copilot-deploy-binaries.yml
+    needs: deploy-stable-infra
     with:
       ENVIRONMENT: stable
       ARTIFACT_NAME: ${{needs.build.outputs.artifact}}


### PR DESCRIPTION
### Motivation and Context
Faster deployments are always nicer.

### Description
Build webapi package and deploy Azure infrastructure in parallel instead of having infrastructure deployment wait for webapi package

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
