### PR TITLE
Fix problem when sqlAdminPassword is not provided

### DIFF
--- a/scripts/deploy/deploy-azure.ps1
+++ b/scripts/deploy/deploy-azure.ps1
@@ -51,7 +51,7 @@ param(
 
     [SecureString]
     # Password for the Postgres database
-    $SqlAdminPassword = "",
+    $SqlAdminPassword,
 
     [switch]
     # Don't deploy Cosmos DB for chat storage - Use volatile memory instead
@@ -107,7 +107,7 @@ $jsonConfig = "
     `\`"memoryStore`\`": { `\`"value`\`": `\`"$MemoryStore`\`" },
     `\`"deployCosmosDB`\`": { `\`"value`\`": $(If (!($NoCosmosDb)) {"true"} Else {"false"}) },
     `\`"deploySpeechServices`\`": { `\`"value`\`": $(If (!($NoSpeechServices)) {"true"} Else {"false"}) },
-    `\`"sqlAdminPassword`\`": { `\`"value`\`": `\`"$(ConvertFrom-SecureString $SqlAdminPassword -AsPlainText)`\`" }
+    `\`"sqlAdminPassword`\`": { `\`"value`\`": `\`"$(If ($SqlAdminPassword) {ConvertFrom-SecureString $SqlAdminPassword -AsPlainText} Else {$null})`\`" }
 }
 "
 


### PR DESCRIPTION
### Motivation and Context
deploy-azure.ps1 gave the following error when no sqlAdminPassword value was provided:
Cannot process argument transformation on parameter 'SqlAdminPassword'. Cannot convert the "" value of type "System.String" to type "System.Security.SecureString".

### Description
Use  null value instead of an empty string

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
