### PR TITLE
Add a dotnet format check workflow

### DIFF
--- a/.github/workflows/copilot-build-backend.yml
+++ b/.github/workflows/copilot-build-backend.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Determine version
         id: gitversion
@@ -57,11 +57,6 @@ jobs:
       - name: Package Copilot Chat WebAPI
         run: |
           scripts\deploy\package-webapi.ps1 -Configuration Release -DotnetFramework net6.0 -TargetRuntime win-x64 -OutputDirectory ${{ github.workspace }}\scripts\deploy -Version ${{ steps.versiontag.outputs.versiontag }} -InformationalVersion "Built from commit ${{ steps.gitversion.outputs.ShortSha }} on $(Get-Date -Format "yyyy-MM-dd")"
-
-      - name: Check formatting of Copilot Chat WebAPI
-        run: |
-          cd webapi/
-          dotnet format --verify-no-changes --verbosity diagnostic
 
       - name: Upload package to artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -59,7 +59,7 @@ jobs:
           fi
           csproj_files=($(printf "%s\n" "${csproj_files[@]}" | sort -u))
           echo "Found ${#csproj_files[@]} unique csproj/sln files: ${csproj_files[*]}"
-          echo "::set-output name=csproj_files::${csproj_files[*]}"
+          echo "csproj_files=${csproj_files[*]}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,8 +1,4 @@
-﻿#
-# This workflow runs the dotnet formatter on all c-sharp code.
-#
-
-name: dotnet-format
+﻿name: dotnet-format
 
 on:
   pull_request:
@@ -17,6 +13,10 @@ concurrency:
 
 jobs:
   check-format:
+    runs-on: ubuntu-latest
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,0 +1,75 @@
+﻿#
+# This workflow runs the dotnet formatter on all c-sharp code.
+#
+
+name: dotnet-format
+
+on:
+  pull_request:
+    branches: ["main", "feature*"]
+    paths:
+      - "webapi/**"
+      - "tools/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-format:
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          clean: true
+
+      - name: Get changed files
+        id: changed-files
+        if: github.event_name == 'pull_request'
+        uses: jitterbit/get-changed-files@v1
+        continue-on-error: true
+
+      - name: No C# files changed
+        id: no-csharp
+        if: github.event_name == 'pull_request' && steps.changed-files.outputs.added_modified == ''
+        run: echo "No C# files changed"
+
+      # This step will loop over the changed files and find the nearest .csproj file for each one, then store the unique csproj files in a variable
+      - name: Find csproj files
+        id: find-csproj
+        if: github.event_name != 'pull_request' || steps.changed-files.outputs.added_modified != '' || steps.changed-files.outcome == 'failure'
+        run: |
+          csproj_files=()
+          if [[ ${{ steps.changed-files.outcome }} == 'success' ]]; then
+            for file in ${{ steps.changed-files.outputs.added_modified }}; do
+              echo "$file was changed"
+              dir="./$file"
+              while [[ $dir != "." && $dir != "/" && $dir != $GITHUB_WORKSPACE ]]; do
+                if find "$dir" -maxdepth 1 -name "*.csproj" -print -quit | grep -q .; then
+                  csproj_files+=("$(find "$dir" -maxdepth 1 -name "*.csproj" -print -quit)")
+                  break
+                fi
+
+                dir=$(echo ${dir%/*})
+              done
+            done
+          else
+            # if the changed-files step failed, run dotnet on the whole sln instead of specific projects
+            csproj_files=$(find ./ -type f -name "*.sln" | tr '\n' ' ');
+          fi
+          csproj_files=($(printf "%s\n" "${csproj_files[@]}" | sort -u))
+          echo "Found ${#csproj_files[@]} unique csproj/sln files: ${csproj_files[*]}"
+          echo "::set-output name=csproj_files::${csproj_files[*]}"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Check formatting
+        if: steps.find-csproj.outputs.csproj_files != ''
+        run: |
+          for csproj in ${{ steps.find-csproj.outputs.csproj_files }}; do
+            echo "Checking formatting for $csproj"
+            dotnet format $csproj --verify-no-changes --verbosity diagnostic
+          done

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -71,5 +71,6 @@ jobs:
         run: |
           for csproj in ${{ steps.find-csproj.outputs.csproj_files }}; do
             echo "Checking formatting for $csproj"
+            dotnet build $csproj
             dotnet format $csproj --verify-no-changes --verbosity diagnostic
           done

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,19 +25,17 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        if: github.event_name == 'pull_request'
         uses: jitterbit/get-changed-files@v1
         continue-on-error: true
 
       - name: No C# files changed
         id: no-csharp
-        if: github.event_name == 'pull_request' && steps.changed-files.outputs.added_modified == ''
+        if: steps.changed-files.outputs.added_modified == ''
         run: echo "No C# files changed"
 
       # This step will loop over the changed files and find the nearest .csproj file for each one, then store the unique csproj files in a variable
       - name: Find csproj files
         id: find-csproj
-        if: github.event_name != 'pull_request' || steps.changed-files.outputs.added_modified != '' || steps.changed-files.outcome == 'failure'
         run: |
           csproj_files=()
           if [[ ${{ steps.changed-files.outcome }} == 'success' ]]; then
@@ -55,6 +53,7 @@ jobs:
             done
           else
             # if the changed-files step failed, run dotnet on the whole sln instead of specific projects
+            echo "Running dotnet format on whole solution"
             csproj_files=$(find ./ -type f -name "*.sln" | tr '\n' ' ');
           fi
           csproj_files=($(printf "%s\n" "${csproj_files[@]}" | sort -u))

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -64,13 +64,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
 
       - name: Check formatting
         if: steps.find-csproj.outputs.csproj_files != ''
         run: |
           for csproj in ${{ steps.find-csproj.outputs.csproj_files }}; do
             echo "Checking formatting for $csproj"
-            dotnet build $csproj
             dotnet format $csproj --verify-no-changes --verbosity diagnostic
           done


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

There is currently no C# format check workflow for PRs. There is a workflow step in copilot-build-backend.yml that checks the format for the webapi, but that happens after the build step.

There are two .Net projects in the repo (soon to be three). It's better to have a workflow that checks the format for the entire repo, instead of having multiple steps scattered around different workflows.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
