### PR TITLE
Fix Null Reference on Content-Saftey service

### DIFF
--- a/webapi/Controllers/DocumentImportController.cs
+++ b/webapi/Controllers/DocumentImportController.cs
@@ -119,7 +119,7 @@ public class DocumentImportController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public bool ContentSafetyStatus()
     {
-        return this._contentSafetyService!.ContentSafetyStatus(this._logger);
+        return this._contentSafetyService?.ContentSafetyStatus(this._logger) ?? false;
     }
 
     /// <summary>

--- a/webapi/Controllers/DocumentImportController.cs
+++ b/webapi/Controllers/DocumentImportController.cs
@@ -81,7 +81,7 @@ public class DocumentImportController : ControllerBase
     private const string ReceiveMessageClientCall = "ReceiveMessage";
     private readonly IOcrEngine _ocrEngine;
     private readonly IAuthInfo _authInfo;
-    private readonly IContentSafetyService? _contentSafetyService = null;
+    private readonly IContentSafetyService? _contentSafetyService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentImportController"/> class.
@@ -298,7 +298,7 @@ public class DocumentImportController : ControllerBase
                     {
                         if (documentImportForm.UseContentSafety)
                         {
-                            if (!this._contentSafetyService!.ContentSafetyStatus(this._logger))
+                            if (this._contentSafetyService == null || !this._contentSafetyService.ContentSafetyStatus(this._logger))
                             {
                                 throw new ArgumentException("Unable to analyze image. Content Safety is currently disabled in the backend.");
                             }
@@ -307,8 +307,8 @@ public class DocumentImportController : ControllerBase
                             try
                             {
                                 // Call the content safety controller to analyze the image
-                                var imageAnalysisResponse = await this._contentSafetyService!.ImageAnalysisAsync(formFile, default);
-                                violations = this._contentSafetyService.ParseViolatedCategories(imageAnalysisResponse, this._contentSafetyService!.Options!.ViolationThreshold);
+                                var imageAnalysisResponse = await this._contentSafetyService.ImageAnalysisAsync(formFile, default);
+                                violations = this._contentSafetyService.ParseViolatedCategories(imageAnalysisResponse, this._contentSafetyService.Options.ViolationThreshold);
                             }
                             catch (Exception ex) when (!ex.IsCriticalException())
                             {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the copilot-chat repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Reported by customer in https://github.com/microsoft/chat-copilot/issues/218

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Use null-coalesce operator to return false when service null

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/copilot-chat/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
