### PR TITLE
Add missing step to README instructions for enabling auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ By default, Chat Copilot runs locally without authentication, using a guest user
       4. Set _Admin consent display name_ and _User consent display name_ to `Access copilot chat as a user`
 
       5. Set _Admin consent description_ and _User consent description_ to `Allows the accesses to the Copilot chat web API as a user`
+   
+   4. Add the web app frontend as an authorized client application
+      1. Click *Add a client application*
+
+      2. For *Client ID*, enter the frontend's application (client) ID
+
+      3. Check the checkbox under *Authorized scopes*
+
+      4. Click *Add application*
 
 4. Add permissions to web app frontend to access web api as user
 

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -64,6 +64,15 @@ You will need two Azure Active Directory (AAD) application registrations -- one 
 
       5. Set *Admin consent description* and *User consent description* to `Allows the accesses to the Chat Copilot web API as a user`
 
+   4. Add the web app frontend as an authorized client application
+      1. Click *Add a client application*
+
+      2. For *Client ID*, enter the frontend's application (client) ID
+
+      3. Check the checkbox under *Authorized scopes*
+
+      4. Click *Add application*
+
 4. Add permissions to web app frontend to access web api as user
    1. Open app registration for web app frontend
 


### PR DESCRIPTION
### Description

When setting up AAD Auth, an additional step is needed to provide consent for the frontend to access the backend for some tenants. Update the READMEs to include this step.

This is solely a documentation update.
