### PR TITLE
Mitigate security warning from regex with env var

### DIFF
--- a/webapp/tests/chat.test.ts
+++ b/webapp/tests/chat.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 /* eslint-disable testing-library/prefer-screen-queries */
 import { test } from '@playwright/test';
 import * as simpletests from './testsBasic';

--- a/webapp/tests/testsBasic.ts
+++ b/webapp/tests/testsBasic.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 import { expect } from '@playwright/test';
 import * as util from './utils';
 

--- a/webapp/tests/testsMultiuser.ts
+++ b/webapp/tests/testsMultiuser.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 import { expect } from '@playwright/test';
 import * as util from './utils';
 

--- a/webapp/tests/testsPlanner.ts
+++ b/webapp/tests/testsPlanner.ts
@@ -1,5 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 import { expect } from '@playwright/test';
-import * as util from './utils'
+import * as util from './utils';
 
 /*
 Summary: Tests if the Copilot Chat can use the Planner with the Klarna plugin, 
@@ -7,21 +9,21 @@ to generate a plan and execute it. Klarna doesnt require any auth credentials.
 */
 export async function klarnaTest(page) {
     await util.loginAndCreateNewChat(page);
-    
+
     // Enable Klarna
     const pluginIdentifierText = 'Klarna ShoppingKlarnaEnableSearch';
     await util.openPluginPopUp(page, pluginIdentifierText);
     await util.enablePluginAndClosePopUp(page);
-    
+
     // Try using Klarna by sending a request to the bot and wait for the response.
-    const klarnaQuery = "Can you get me a list of prices of surface notebooks?";
+    const klarnaQuery = 'Can you get me a list of prices of surface notebooks?';
     await util.sendChatMessageAndWaitForResponse(page, klarnaQuery);
     await util.executePlanAndWaitForResponse(page);
 
     // Expect the last message to be the bot's response.
     const chatHistoryItems = page.getByTestId(new RegExp('chat-history-item-*'));
     await expect(chatHistoryItems.last()).toHaveAttribute('data-username', 'Copilot');
-    
+
     // Specifically accessing the us site of klarna so any results should have a dollar sign
     await expect(chatHistoryItems.last()).toContainText('$');
 
@@ -40,16 +42,16 @@ export async function jiraTest(page) {
 
     // Enable Jira
     await util.openPluginPopUp(page, 'JiraAtlassianEnableAuthorize');
-    
+
     // Enter Auth Credentials and server url
     await page.locator('#plugin-email-input').fill(process.env.REACT_APP_TEST_JIRA_EMAIL as string);
     await page.locator('#plugin-pat-input').fill(process.env.REACT_APP_TEST_JIRA_ACCESS_TOKEN as string);
     await page.getByPlaceholder('Enter the server url').fill(process.env.REACT_APP_TEST_JIRA_SERVER_URL as string);
-    
+
     await util.enablePluginAndClosePopUp(page);
-    
+
     // Try using Jira by sending a request to the bot and wait for it to respond.
-    const jiraQuery = "Can you Get Issue details about SKTES-1 from jira ?";
+    const jiraQuery = 'Can you Get Issue details about SKTES-1 from jira ?';
     await util.sendChatMessageAndWaitForResponse(page, jiraQuery);
     await util.executePlanAndWaitForResponse(page);
 
@@ -60,7 +62,7 @@ export async function jiraTest(page) {
 
     var chatbotResponse = await util.getLastChatMessageContentsAsStringWHistory(page, chatHistoryItems);
     await util.disablePluginAndEvaluateResponse(page, jiraQuery, chatbotResponse);
-    
+
     await util.postUnitTest(page);
 }
 
@@ -70,19 +72,23 @@ to generate a plan and execute it. The Github plugin uses a PAT token for auth.
 */
 export async function githubTest(page) {
     await util.loginAndCreateNewChat(page);
-    
+
     // Enable Github
     await util.openPluginPopUp(page, 'GitHubMicrosoftEnableIntegrate');
-    
+
     // Enter Auth Credentials and server url
     await page.locator('#plugin-pat-input').fill(process.env.REACT_APP_TEST_GITHUB_ACCESS_TOKEN as string);
-    await page.getByPlaceholder('Enter the account owner of repository').fill(process.env.REACT_APP_TEST_GITHUB_ACCOUNT_OWNER as string);
-    await page.getByPlaceholder('Enter the name of repository').fill(process.env.REACT_APP_TEST_GITHUB_REPOSITORY_NAME as string);
-    
+    await page
+        .getByPlaceholder('Enter the account owner of repository')
+        .fill(process.env.REACT_APP_TEST_GITHUB_ACCOUNT_OWNER as string);
+    await page
+        .getByPlaceholder('Enter the name of repository')
+        .fill(process.env.REACT_APP_TEST_GITHUB_REPOSITORY_NAME as string);
+
     await util.enablePluginAndClosePopUp(page);
-    
+
     // Try using Github by sending a request to the bot and wait for it to respond.
-    const githubQuery = "List the 5 most recent open pull requests";
+    const githubQuery = 'List the 5 most recent open pull requests';
     await util.sendChatMessageAndWaitForResponse(page, githubQuery);
     await util.executePlanAndWaitForResponse(page);
 

--- a/webapp/tests/utils.ts
+++ b/webapp/tests/utils.ts
@@ -13,7 +13,7 @@ export async function loginHelper(page, useraccount, password) {
     // Expect the page to contain a "Login" button.
     await page.getByTestId('signinButton').click();
     // Clicking the login button should redirect to the login page.
-    await expect(page).toHaveURL(new RegExp(`${process.env.REACT_APP_AAD_AUTHORITY}.*`));
+    await page.url().startsWith(process.env.REACT_APP_AAD_AUTHORITY);
     // Login with the test user.
     await page.getByPlaceholder('Email, phone, or Skype').click();
     await page.getByPlaceholder('Email, phone, or Skype').fill(useraccount as string);
@@ -36,7 +36,7 @@ export async function loginHelperAnotherUser(page, useraccount, password) {
     // Expect the page to contain a "Login" button.
     await page.getByRole('button').click();
     // Clicking the login button should redirect to the login page.
-    await expect(page).toHaveURL(new RegExp(`${process.env.REACT_APP_AAD_AUTHORITY}.*`));
+    await page.url().startsWith(process.env.REACT_APP_AAD_AUTHORITY);
     // Login with the another user account.
     await page.getByRole('button', { name: 'Use another account' }).click();
     await page.getByPlaceholder('Email, phone, or Skype').click();


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We have to security warning from Code scanning:
https://github.com/microsoft/chat-copilot/security/code-scanning/14
https://github.com/microsoft/chat-copilot/security/code-scanning/15


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Replace regex with startsWith.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
