### PR TITLE
Delete-chat fix to also remove document index

### DIFF
--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -346,7 +346,9 @@ public class ChatHistoryController : ControllerBase
         // Create and store the tasks for deleting semantic memories.
         // TODO: [Issue #47] Filtering memory collections by name might be fragile.
         var memoryCollections = (await this._memoryStore.GetCollectionsAsync(cancellationToken).ToListAsync<string>())
-            .Where(collection => collection.StartsWith(chatId, StringComparison.OrdinalIgnoreCase));
+            .Where(collection =>
+                collection.StartsWith(chatId, StringComparison.OrdinalIgnoreCase) || // chat memory
+                collection.Equals($"chat-documents-{chatId}", StringComparison.OrdinalIgnoreCase)); // document memory
         foreach (var collection in memoryCollections)
         {
             cleanupTasks.Add(this._memoryStore.DeleteCollectionAsync(collection, cancellationToken));


### PR DESCRIPTION
### Motivation and Context
Add `$"chat-documents-{chatId}"` to filter for `memoryCollections`. Delete chat currently only removing two indexes and leaving one orphaned.

Noticed this using our INT/proud-river deployment.

### Description
Here is the index naming currently used:

![image](https://github.com/microsoft/chat-copilot/assets/66376200/0992d28c-2dec-4a6c-b8fe-8fc705d25950)


### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
