### PR TITLE
Adding Timeout Limit option for /chat requests

### DIFF
--- a/webapi/Controllers/ChatController.cs
+++ b/webapi/Controllers/ChatController.cs
@@ -158,9 +158,9 @@ public class ChatController : ControllerBase, IDisposable
 
             if (result.LastException is OperationCanceledException || result.LastException?.InnerException is OperationCanceledException)
             {
-                // Log the timeout and return a 408 response
+                // Log the timeout and return a 504 response
                 this._logger.LogError("The chat operation timed out.");
-                return this.StatusCode(StatusCodes.Status408RequestTimeout);
+                return this.StatusCode(StatusCodes.Status504GatewayTimeout, "The chat operation timed out.");
             }
 
             return this.BadRequest(result.LastException!.Message);

--- a/webapi/Options/ServiceOptions.cs
+++ b/webapi/Options/ServiceOptions.cs
@@ -12,6 +12,12 @@ public class ServiceOptions
     public const string PropertyName = "Service";
 
     /// <summary>
+    /// Timeout limit on requests to the service in seconds.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public double? TimeoutLimitInS { get; set; }
+
+    /// <summary>
     /// Configuration Key Vault URI
     /// </summary>
     [Url]

--- a/webapi/Skills/ChatSkills/ChatSkill.cs
+++ b/webapi/Skills/ChatSkills/ChatSkill.cs
@@ -124,10 +124,11 @@ public class ChatSkill
     /// Extract user intent from the conversation history.
     /// </summary>
     /// <param name="context">The SKContext.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     [SKFunction, Description("Extract user intent")]
     [SKParameter("chatId", "Chat ID to extract history from")]
     [SKParameter("audience", "The audience the chat bot is interacting with.")]
-    public async Task<string> ExtractUserIntentAsync(SKContext context)
+    public async Task<string> ExtractUserIntentAsync(SKContext context, CancellationToken cancellationToken = default)
     {
         var tokenLimit = this._promptOptions.CompletionTokenLimit;
         var historyTokenBudget =
@@ -153,7 +154,8 @@ public class ChatSkill
 
         var result = await completionFunction.InvokeAsync(
             intentExtractionContext,
-            settings: this.CreateIntentCompletionSettings()
+            settings: this.CreateIntentCompletionSettings(),
+            cancellationToken
         );
 
         // Get token usage from ChatCompletion result and add to context
@@ -168,9 +170,11 @@ public class ChatSkill
     /// Extract the list of participants from the conversation history.
     /// Note that only those who have spoken will be included.
     /// </summary>
+    /// <param name="context">The SKContext.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     [SKFunction, Description("Extract audience list")]
     [SKParameter("chatId", "Chat ID to extract history from")]
-    public async Task<string> ExtractAudienceAsync(SKContext context)
+    public async Task<string> ExtractAudienceAsync(SKContext context, CancellationToken cancellationToken = default)
     {
         var tokenLimit = this._promptOptions.CompletionTokenLimit;
         var historyTokenBudget =
@@ -194,7 +198,8 @@ public class ChatSkill
 
         var result = await completionFunction.InvokeAsync(
             audienceExtractionContext,
-            settings: this.CreateIntentCompletionSettings()
+            settings: this.CreateIntentCompletionSettings(),
+            cancellationToken
         );
 
         // Get token usage from ChatCompletion result and add to context
@@ -209,10 +214,12 @@ public class ChatSkill
     /// Extract chat history.
     /// </summary>
     /// <param name="context">Contains the 'tokenLimit' controlling the length of the prompt.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     [SKFunction, Description("Extract chat history")]
     public async Task<string> ExtractChatHistoryAsync(
         [Description("Chat ID to extract history from")] string chatId,
-        [Description("Maximum number of tokens")] int tokenLimit)
+        [Description("Maximum number of tokens")] int tokenLimit,
+        CancellationToken cancellationToken = default)
     {
         var messages = await this._chatMessageRepository.FindByChatIdAsync(chatId);
         var sortedMessages = messages.OrderByDescending(m => m.Timestamp);
@@ -263,6 +270,7 @@ public class ChatSkill
     /// messages to memory, and fill in the necessary context variables for completing the
     /// prompt that will be rendered by the template engine.
     /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
     [SKFunction, Description("Get chat response")]
     public async Task<SKContext> ChatAsync(
         [Description("The new message")] string message,
@@ -276,11 +284,11 @@ public class ChatSkill
         CancellationToken cancellationToken = default)
     {
         // Set the system description in the prompt options
-        await this.SetSystemDescriptionAsync(chatId);
+        await this.SetSystemDescriptionAsync(chatId, cancellationToken);
 
         // Save this new message to memory such that subsequent chat responses can use it
-        await this.UpdateBotResponseStatusOnClient(chatId, "Saving user message to chat history");
-        await this.SaveNewMessageAsync(message, userId, userName, chatId, messageType);
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Saving user message to chat history", cancellationToken);
+        await this.SaveNewMessageAsync(message, userId, userName, chatId, messageType, cancellationToken);
 
         // Clone the context to avoid modifying the original context variables.
         var chatContext = context.Clone();
@@ -292,14 +300,14 @@ public class ChatSkill
         if (!string.IsNullOrWhiteSpace(planJson) &&
             !string.IsNullOrEmpty(messageId))
         {
-            await this.UpdateChatMessageContentAsync(planJson, messageId);
+            await this.UpdateChatMessageContentAsync(planJson, messageId, cancellationToken);
         }
 
         ChatMessage chatMessage;
         if (chatContext.Variables.ContainsKey("userCancelledPlan"))
         {
             // Save hardcoded response if user cancelled plan
-            chatMessage = await this.SaveNewResponseAsync("I am sorry the plan did not meet your goals.", string.Empty, chatId, userId, TokenUtilities.EmptyTokenUsages());
+            chatMessage = await this.SaveNewResponseAsync("I am sorry the plan did not meet your goals.", string.Empty, chatId, userId, TokenUtilities.EmptyTokenUsages(), cancellationToken);
         }
         else
         {
@@ -329,30 +337,31 @@ public class ChatSkill
     /// <param name="chatId">The chat ID</param>
     /// <param name="userId">The user ID</param>
     /// <param name="chatContext">The SKContext.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message containing the model-generated response.</returns>
     private async Task<ChatMessage> GetChatResponseAsync(string chatId, string userId, SKContext chatContext, CancellationToken cancellationToken)
     {
         // Get the audience
-        await this.UpdateBotResponseStatusOnClient(chatId, "Extracting audience");
-        var audience = await this.GetAudienceAsync(chatContext);
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Extracting audience", cancellationToken);
+        var audience = await this.GetAudienceAsync(chatContext, cancellationToken);
         chatContext.ThrowIfFailed();
 
         // Extract user intent from the conversation history.
-        await this.UpdateBotResponseStatusOnClient(chatId, "Extracting user intent");
-        var userIntent = await this.GetUserIntentAsync(chatContext);
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Extracting user intent", cancellationToken);
+        var userIntent = await this.GetUserIntentAsync(chatContext, cancellationToken);
         chatContext.ThrowIfFailed();
 
         chatContext.Variables.Set("audience", audience);
         chatContext.Variables.Set("userIntent", userIntent);
 
         // Calculate the remaining token budget.
-        await this.UpdateBotResponseStatusOnClient(chatId, "Calculating remaining token budget");
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Calculating remaining token budget", cancellationToken);
         var remainingToken = this.GetChatContextTokenLimit(audience, userIntent);
 
         // Acquire external information from planner
-        await this.UpdateBotResponseStatusOnClient(chatId, "Acquiring external information from planner");
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Acquiring external information from planner", cancellationToken);
         var externalInformationTokenLimit = (int)(remainingToken * this._promptOptions.ExternalInformationContextWeight);
-        var planResult = await this.AcquireExternalInformationAsync(chatContext, userIntent, externalInformationTokenLimit);
+        var planResult = await this.AcquireExternalInformationAsync(chatContext, userIntent, externalInformationTokenLimit, cancellationToken);
         chatContext.ThrowIfFailed();
 
         // Extract additional details about planner execution in chat context
@@ -371,20 +380,24 @@ public class ChatSkill
 
             // Save a new response to the chat history with the proposed plan content
             return await this.SaveNewResponseAsync(
-                JsonSerializer.Serialize<ProposedPlan>(proposedPlan), prompt, chatId, userId,
+                JsonSerializer.Serialize<ProposedPlan>(proposedPlan),
+                prompt,
+                chatId,
+                userId,
                 // TODO: [Issue #2106] Accommodate plan token usage differently
-                this.GetTokenUsagesAsync(chatContext)
+                this.GetTokenUsages(chatContext),
+                cancellationToken
             );
         }
 
         // Query relevant semantic and document memories
-        await this.UpdateBotResponseStatusOnClient(chatId, "Extracting semantic and document memories");
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Extracting semantic and document memories", cancellationToken);
         var chatMemoriesTokenLimit = (int)(remainingToken * this._promptOptions.MemoriesResponseContextWeight);
         var documentContextTokenLimit = (int)(remainingToken * this._promptOptions.DocumentContextWeight);
 
         string[] tasks = await Task.WhenAll<string>(
-            this._semanticChatMemorySkill.QueryMemoriesAsync(userIntent, chatId, chatMemoriesTokenLimit, this._kernel.Memory),
-            this._documentMemorySkill.QueryDocumentsAsync(userIntent, chatId, documentContextTokenLimit, this._kernel.Memory)
+            this._semanticChatMemorySkill.QueryMemoriesAsync(userIntent, chatId, chatMemoriesTokenLimit, this._kernel.Memory, cancellationToken),
+            this._documentMemorySkill.QueryDocumentsAsync(userIntent, chatId, documentContextTokenLimit, this._kernel.Memory, cancellationToken)
         );
 
         var chatMemories = tasks[0];
@@ -400,8 +413,8 @@ public class ChatSkill
         // Append the chat history, if allowed.
         if (chatHistoryTokenLimit > 0)
         {
-            await this.UpdateBotResponseStatusOnClient(chatId, "Extracting chat history");
-            chatHistory = await this.ExtractChatHistoryAsync(chatId, chatHistoryTokenLimit);
+            await this.UpdateBotResponseStatusOnClientAsync(chatId, "Extracting chat history", cancellationToken);
+            chatHistory = await this.ExtractChatHistoryAsync(chatId, chatHistoryTokenLimit, cancellationToken);
             chatContext.ThrowIfFailed();
             chatContextText = $"{chatContextText}\n{chatHistory}";
         }
@@ -435,11 +448,11 @@ public class ChatSkill
         chatContext.ThrowIfFailed();
 
         // Stream the response to the client
-        await this.UpdateBotResponseStatusOnClient(chatId, "Generating bot response");
-        var chatMessage = await this.StreamResponseToClient(chatId, userId, promptView);
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Generating bot response", cancellationToken);
+        var chatMessage = await this.StreamResponseToClientAsync(chatId, userId, promptView, cancellationToken);
 
         // Extract semantic chat memory
-        await this.UpdateBotResponseStatusOnClient(chatId, "Generating semantic chat memory");
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Generating semantic chat memory", cancellationToken);
         await SemanticChatMemoryExtractor.ExtractSemanticChatMemoryAsync(
             chatId,
             this._kernel,
@@ -449,12 +462,12 @@ public class ChatSkill
             cancellationToken);
 
         // Calculate total token usage for dependency functions and prompt template and send to client
-        await this.UpdateBotResponseStatusOnClient(chatId, "Calculating token usage");
-        chatMessage.TokenUsage = this.GetTokenUsagesAsync(chatContext, chatMessage.Content);
-        await this.UpdateMessageOnClient(chatMessage);
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Calculating token usage", cancellationToken);
+        chatMessage.TokenUsage = this.GetTokenUsages(chatContext, chatMessage.Content);
+        await this.UpdateMessageOnClient(chatMessage, cancellationToken);
 
         // Save the message with final completion token usage
-        await this.UpdateBotResponseStatusOnClient(chatId, "Saving message to chat history");
+        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Saving message to chat history", cancellationToken);
         await this._chatMessageRepository.UpsertAsync(chatMessage);
 
         return chatMessage;
@@ -464,11 +477,12 @@ public class ChatSkill
     /// Helper function that creates the correct context variables to
     /// extract the audience from a conversation history.
     /// </summary>
-    private async Task<string> GetAudienceAsync(SKContext context)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task<string> GetAudienceAsync(SKContext context, CancellationToken cancellationToken = default)
     {
         SKContext audienceContext = context.Clone();
 
-        var audience = await this.ExtractAudienceAsync(audienceContext);
+        var audience = await this.ExtractAudienceAsync(audienceContext, cancellationToken);
 
         // Copy token usage into original chat context
         var functionKey = TokenUtilities.GetFunctionKey(context.Logger, "SystemAudienceExtraction")!;
@@ -487,14 +501,15 @@ public class ChatSkill
     /// Helper function that creates the correct context variables to
     /// extract the user intent from the conversation history.
     /// </summary>
-    private async Task<string> GetUserIntentAsync(SKContext context)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task<string> GetUserIntentAsync(SKContext context, CancellationToken cancellationToken = default)
     {
         // TODO: [Issue #51] Regenerate user intent if plan was modified
         if (!context.Variables.TryGetValue("planUserIntent", out string? userIntent))
         {
             SKContext intentContext = context.Clone();
 
-            userIntent = await this.ExtractUserIntentAsync(intentContext);
+            userIntent = await this.ExtractUserIntentAsync(intentContext, cancellationToken);
 
             // Copy token usage into original chat context
             var functionKey = TokenUtilities.GetFunctionKey(context.Logger, "SystemIntentExtraction")!;
@@ -516,9 +531,10 @@ public class ChatSkill
     /// <param name="context">The SKContext.</param>
     /// <param name="userIntent">The user intent.</param>
     /// <param name="tokenLimit">Maximum number of tokens.</param>
-    private Task<string> QueryChatMemoriesAsync(SKContext context, string userIntent, int tokenLimit)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private Task<string> QueryChatMemoriesAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken = default)
     {
-        return this._semanticChatMemorySkill.QueryMemoriesAsync(userIntent, context.Variables["chatId"], tokenLimit, this._kernel.Memory);
+        return this._semanticChatMemorySkill.QueryMemoriesAsync(userIntent, context.Variables["chatId"], tokenLimit, this._kernel.Memory, cancellationToken);
     }
 
     /// <summary>
@@ -528,9 +544,10 @@ public class ChatSkill
     /// <param name="context">The SKContext.</param>
     /// <param name="userIntent">The user intent.</param>
     /// <param name="tokenLimit">Maximum number of tokens.</param>
-    private Task<string> QueryDocumentsAsync(SKContext context, string userIntent, int tokenLimit)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private Task<string> QueryDocumentsAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken = default)
     {
-        return this._documentMemorySkill.QueryDocumentsAsync(userIntent, context.Variables["chatId"], tokenLimit, this._kernel.Memory);
+        return this._documentMemorySkill.QueryDocumentsAsync(userIntent, context.Variables["chatId"], tokenLimit, this._kernel.Memory, cancellationToken);
     }
 
     /// <summary>
@@ -540,12 +557,13 @@ public class ChatSkill
     /// <param name="context">The SKContext.</param>
     /// <param name="userIntent">The user intent.</param>
     /// <param name="tokenLimit">Maximum number of tokens.</param>
-    private async Task<string> AcquireExternalInformationAsync(SKContext context, string userIntent, int tokenLimit)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task<string> AcquireExternalInformationAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken = default)
     {
         SKContext planContext = context.Clone();
         planContext.Variables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
 
-        var plan = await this._externalInformationSkill.AcquireExternalInformationAsync(userIntent, planContext);
+        var plan = await this._externalInformationSkill.AcquireExternalInformationAsync(userIntent, planContext, cancellationToken);
 
         // Propagate the error
         planContext.ThrowIfFailed();
@@ -561,7 +579,8 @@ public class ChatSkill
     /// <param name="userName"></param>
     /// <param name="chatId">The chat ID</param>
     /// <param name="type">Type of the message</param>
-    private async Task<ChatMessage> SaveNewMessageAsync(string message, string userId, string userName, string chatId, string type)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task<ChatMessage> SaveNewMessageAsync(string message, string userId, string userName, string chatId, string type, CancellationToken cancellationToken = default)
     {
         // Make sure the chat exists.
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId))
@@ -593,8 +612,9 @@ public class ChatSkill
     /// <param name="chatId">The chat ID</param>
     /// <param name="userId">The user ID</param>
     ///  <param name="tokenUsage">Total token usage of response completion</param>
+    ///  <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message.</returns>
-    private async Task<ChatMessage> SaveNewResponseAsync(string response, string prompt, string chatId, string userId, Dictionary<string, int>? tokenUsage)
+    private async Task<ChatMessage> SaveNewResponseAsync(string response, string prompt, string chatId, string userId, Dictionary<string, int>? tokenUsage, CancellationToken cancellationToken = default)
     {
         // Make sure the chat exists.
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId))
@@ -603,7 +623,7 @@ public class ChatSkill
         }
 
         // Save message to chat history
-        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, prompt, response, tokenUsage);
+        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, prompt, response, tokenUsage, cancellationToken);
         await this._chatMessageRepository.UpsertAsync(chatMessage);
         return chatMessage;
     }
@@ -613,7 +633,8 @@ public class ChatSkill
     /// </summary>
     /// <param name="updatedResponse">Updated response from the chat.</param>
     /// <param name="messageId">The chat message ID</param>
-    private async Task UpdateChatMessageContentAsync(string updatedResponse, string messageId)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task UpdateChatMessageContentAsync(string updatedResponse, string messageId, CancellationToken cancellationToken = default)
     {
         // Make sure the chat exists.
         var chatMessage = await this._chatMessageRepository.FindByIdAsync(messageId);
@@ -685,7 +706,7 @@ public class ChatSkill
     /// <param name="chatContext">Context maintained during response generation.</param>
     /// <param name="content">String representing bot response. If null, response is still being generated or was hardcoded.</param>
     /// <returns>Dictionary containing function to token usage mapping for each total that's defined.</returns>
-    private Dictionary<string, int> GetTokenUsagesAsync(SKContext chatContext, string? content = null)
+    private Dictionary<string, int> GetTokenUsages(SKContext chatContext, string? content = null)
     {
         var tokenUsageDict = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
@@ -712,21 +733,22 @@ public class ChatSkill
     /// <param name="chatId">The chat ID</param>
     /// <param name="userId">The user ID</param>
     /// <param name="prompt">Prompt used to generate the response</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message</returns>
-    private async Task<ChatMessage> StreamResponseToClient(string chatId, string userId, BotResponsePrompt prompt)
+    private async Task<ChatMessage> StreamResponseToClientAsync(string chatId, string userId, BotResponsePrompt prompt, CancellationToken cancellationToken = default)
     {
         // Create the stream
         var chatCompletion = this._kernel.GetService<IChatCompletion>();
-        var stream = chatCompletion.GenerateMessageStreamAsync(chatCompletion.CreateNewChat(prompt.RawContent), this.CreateChatRequestSettings());
+        var stream = chatCompletion.GenerateMessageStreamAsync(chatCompletion.CreateNewChat(prompt.RawContent), this.CreateChatRequestSettings(), cancellationToken);
 
         // Create message on client
-        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, JsonSerializer.Serialize(prompt), string.Empty);
+        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, JsonSerializer.Serialize(prompt), string.Empty, cancellationToken: cancellationToken);
 
         // Stream the message to the client
         await foreach (string contentPiece in stream)
         {
             chatMessage.Content += contentPiece;
-            await this.UpdateMessageOnClient(chatMessage);
+            await this.UpdateMessageOnClient(chatMessage, cancellationToken);
         }
 
         return chatMessage;
@@ -740,11 +762,12 @@ public class ChatSkill
     /// <param name="prompt">Prompt used to generate the message</param>
     /// <param name="content">Content of the message</param>
     /// <param name="tokenUsage">Total token usage of response completion</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message</returns>
-    private async Task<ChatMessage> CreateBotMessageOnClient(string chatId, string userId, string prompt, string content, Dictionary<string, int>? tokenUsage = null)
+    private async Task<ChatMessage> CreateBotMessageOnClient(string chatId, string userId, string prompt, string content, Dictionary<string, int>? tokenUsage = null, CancellationToken cancellationToken = default)
     {
         var chatMessage = ChatMessage.CreateBotResponseMessage(chatId, content, prompt, tokenUsage);
-        await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveMessage", chatId, userId, chatMessage);
+        await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveMessage", chatId, userId, chatMessage, cancellationToken);
         return chatMessage;
     }
 
@@ -752,9 +775,10 @@ public class ChatSkill
     /// Update the response on the client.
     /// </summary>
     /// <param name="message">The message</param>
-    private async Task UpdateMessageOnClient(ChatMessage message)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task UpdateMessageOnClient(ChatMessage message, CancellationToken cancellationToken = default)
     {
-        await this._messageRelayHubContext.Clients.Group(message.ChatId).SendAsync("ReceiveMessageUpdate", message);
+        await this._messageRelayHubContext.Clients.Group(message.ChatId).SendAsync("ReceiveMessageUpdate", message, cancellationToken);
     }
 
     /// <summary>
@@ -762,17 +786,19 @@ public class ChatSkill
     /// </summary>
     /// <param name="chatId">The chat ID</param>
     /// <param name="status">Current status of the response</param>
-    private async Task UpdateBotResponseStatusOnClient(string chatId, string status)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task UpdateBotResponseStatusOnClientAsync(string chatId, string status, CancellationToken cancellationToken = default)
     {
-        await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveBotResponseStatus", chatId, status);
+        await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveBotResponseStatus", chatId, status, cancellationToken);
     }
 
     /// <summary>
     /// Set the system description in the prompt options.
     /// </summary>
     /// <param name="chatId">Id of the chat session</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <exception cref="ArgumentException">Throw if the chat session does not exist.</exception>
-    private async Task SetSystemDescriptionAsync(string chatId)
+    private async Task SetSystemDescriptionAsync(string chatId, CancellationToken cancellationToken = default)
     {
         ChatSession? chatSession = null;
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId, callback: v => chatSession = v))

--- a/webapi/Skills/ChatSkills/ChatSkill.cs
+++ b/webapi/Skills/ChatSkills/ChatSkill.cs
@@ -478,7 +478,7 @@ public class ChatSkill
     /// extract the audience from a conversation history.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task<string> GetAudienceAsync(SKContext context, CancellationToken cancellationToken = default)
+    private async Task<string> GetAudienceAsync(SKContext context, CancellationToken cancellationToken)
     {
         SKContext audienceContext = context.Clone();
 
@@ -502,7 +502,7 @@ public class ChatSkill
     /// extract the user intent from the conversation history.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task<string> GetUserIntentAsync(SKContext context, CancellationToken cancellationToken = default)
+    private async Task<string> GetUserIntentAsync(SKContext context, CancellationToken cancellationToken)
     {
         // TODO: [Issue #51] Regenerate user intent if plan was modified
         if (!context.Variables.TryGetValue("planUserIntent", out string? userIntent))
@@ -532,7 +532,7 @@ public class ChatSkill
     /// <param name="userIntent">The user intent.</param>
     /// <param name="tokenLimit">Maximum number of tokens.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private Task<string> QueryChatMemoriesAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken = default)
+    private Task<string> QueryChatMemoriesAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken)
     {
         return this._semanticChatMemorySkill.QueryMemoriesAsync(userIntent, context.Variables["chatId"], tokenLimit, this._kernel.Memory, cancellationToken);
     }
@@ -545,7 +545,7 @@ public class ChatSkill
     /// <param name="userIntent">The user intent.</param>
     /// <param name="tokenLimit">Maximum number of tokens.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private Task<string> QueryDocumentsAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken = default)
+    private Task<string> QueryDocumentsAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken)
     {
         return this._documentMemorySkill.QueryDocumentsAsync(userIntent, context.Variables["chatId"], tokenLimit, this._kernel.Memory, cancellationToken);
     }
@@ -558,7 +558,7 @@ public class ChatSkill
     /// <param name="userIntent">The user intent.</param>
     /// <param name="tokenLimit">Maximum number of tokens.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task<string> AcquireExternalInformationAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken = default)
+    private async Task<string> AcquireExternalInformationAsync(SKContext context, string userIntent, int tokenLimit, CancellationToken cancellationToken)
     {
         SKContext planContext = context.Clone();
         planContext.Variables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
@@ -580,7 +580,7 @@ public class ChatSkill
     /// <param name="chatId">The chat ID</param>
     /// <param name="type">Type of the message</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task<ChatMessage> SaveNewMessageAsync(string message, string userId, string userName, string chatId, string type, CancellationToken cancellationToken = default)
+    private async Task<ChatMessage> SaveNewMessageAsync(string message, string userId, string userName, string chatId, string type, CancellationToken cancellationToken)
     {
         // Make sure the chat exists.
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId))
@@ -614,7 +614,7 @@ public class ChatSkill
     ///  <param name="tokenUsage">Total token usage of response completion</param>
     ///  <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message.</returns>
-    private async Task<ChatMessage> SaveNewResponseAsync(string response, string prompt, string chatId, string userId, Dictionary<string, int>? tokenUsage, CancellationToken cancellationToken = default)
+    private async Task<ChatMessage> SaveNewResponseAsync(string response, string prompt, string chatId, string userId, Dictionary<string, int>? tokenUsage, CancellationToken cancellationToken)
     {
         // Make sure the chat exists.
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId))
@@ -634,7 +634,7 @@ public class ChatSkill
     /// <param name="updatedResponse">Updated response from the chat.</param>
     /// <param name="messageId">The chat message ID</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task UpdateChatMessageContentAsync(string updatedResponse, string messageId, CancellationToken cancellationToken = default)
+    private async Task UpdateChatMessageContentAsync(string updatedResponse, string messageId, CancellationToken cancellationToken)
     {
         // Make sure the chat exists.
         var chatMessage = await this._chatMessageRepository.FindByIdAsync(messageId);
@@ -735,7 +735,7 @@ public class ChatSkill
     /// <param name="prompt">Prompt used to generate the response</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message</returns>
-    private async Task<ChatMessage> StreamResponseToClientAsync(string chatId, string userId, BotResponsePrompt prompt, CancellationToken cancellationToken = default)
+    private async Task<ChatMessage> StreamResponseToClientAsync(string chatId, string userId, BotResponsePrompt prompt, CancellationToken cancellationToken)
     {
         // Create the stream
         var chatCompletion = this._kernel.GetService<IChatCompletion>();
@@ -764,7 +764,7 @@ public class ChatSkill
     /// <param name="tokenUsage">Total token usage of response completion</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created chat message</returns>
-    private async Task<ChatMessage> CreateBotMessageOnClient(string chatId, string userId, string prompt, string content, Dictionary<string, int>? tokenUsage = null, CancellationToken cancellationToken = default)
+    private async Task<ChatMessage> CreateBotMessageOnClient(string chatId, string userId, string prompt, string content, Dictionary<string, int>? tokenUsage = null, CancellationToken cancellationToken)
     {
         var chatMessage = ChatMessage.CreateBotResponseMessage(chatId, content, prompt, tokenUsage);
         await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveMessage", chatId, userId, chatMessage, cancellationToken);
@@ -776,7 +776,7 @@ public class ChatSkill
     /// </summary>
     /// <param name="message">The message</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task UpdateMessageOnClient(ChatMessage message, CancellationToken cancellationToken = default)
+    private async Task UpdateMessageOnClient(ChatMessage message, CancellationToken cancellationToken)
     {
         await this._messageRelayHubContext.Clients.Group(message.ChatId).SendAsync("ReceiveMessageUpdate", message, cancellationToken);
     }
@@ -787,7 +787,7 @@ public class ChatSkill
     /// <param name="chatId">The chat ID</param>
     /// <param name="status">Current status of the response</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    private async Task UpdateBotResponseStatusOnClientAsync(string chatId, string status, CancellationToken cancellationToken = default)
+    private async Task UpdateBotResponseStatusOnClientAsync(string chatId, string status, CancellationToken cancellationToken)
     {
         await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveBotResponseStatus", chatId, status, cancellationToken);
     }
@@ -798,7 +798,7 @@ public class ChatSkill
     /// <param name="chatId">Id of the chat session</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <exception cref="ArgumentException">Throw if the chat session does not exist.</exception>
-    private async Task SetSystemDescriptionAsync(string chatId, CancellationToken cancellationToken = default)
+    private async Task SetSystemDescriptionAsync(string chatId, CancellationToken cancellationToken)
     {
         ChatSession? chatSession = null;
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId, callback: v => chatSession = v))

--- a/webapi/Skills/ChatSkills/ChatSkill.cs
+++ b/webapi/Skills/ChatSkills/ChatSkill.cs
@@ -623,7 +623,7 @@ public class ChatSkill
         }
 
         // Save message to chat history
-        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, prompt, response, tokenUsage, cancellationToken);
+        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, prompt, response, cancellationToken, tokenUsage);
         await this._chatMessageRepository.UpsertAsync(chatMessage);
         return chatMessage;
     }
@@ -742,7 +742,7 @@ public class ChatSkill
         var stream = chatCompletion.GenerateMessageStreamAsync(chatCompletion.CreateNewChat(prompt.RawContent), this.CreateChatRequestSettings(), cancellationToken);
 
         // Create message on client
-        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, JsonSerializer.Serialize(prompt), string.Empty, cancellationToken: cancellationToken);
+        var chatMessage = await this.CreateBotMessageOnClient(chatId, userId, JsonSerializer.Serialize(prompt), string.Empty, cancellationToken);
 
         // Stream the message to the client
         await foreach (string contentPiece in stream)
@@ -761,10 +761,10 @@ public class ChatSkill
     /// <param name="userId">The user ID</param>
     /// <param name="prompt">Prompt used to generate the message</param>
     /// <param name="content">Content of the message</param>
-    /// <param name="tokenUsage">Total token usage of response completion</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="tokenUsage">Total token usage of response completion</param>
     /// <returns>The created chat message</returns>
-    private async Task<ChatMessage> CreateBotMessageOnClient(string chatId, string userId, string prompt, string content, Dictionary<string, int>? tokenUsage = null, CancellationToken cancellationToken)
+    private async Task<ChatMessage> CreateBotMessageOnClient(string chatId, string userId, string prompt, string content, CancellationToken cancellationToken, Dictionary<string, int>? tokenUsage = null)
     {
         var chatMessage = ChatMessage.CreateBotResponseMessage(chatId, content, prompt, tokenUsage);
         await this._messageRelayHubContext.Clients.Group(chatId).SendAsync("ReceiveMessage", chatId, userId, chatMessage, cancellationToken);

--- a/webapi/Skills/ChatSkills/DocumentMemorySkill.cs
+++ b/webapi/Skills/ChatSkills/DocumentMemorySkill.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Options;
 using Microsoft.Extensions.Logging;
@@ -51,12 +52,14 @@ public class DocumentMemorySkill
     /// </summary>
     /// <param name="query">Query to match.</param>
     /// <param name="context">The SkContext.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     [SKFunction, Description("Query documents in the memory given a user message")]
     public async Task<string> QueryDocumentsAsync(
         [Description("Query to match.")] string query,
         [Description("ID of the chat that owns the documents")] string chatId,
         [Description("Maximum number of tokens")] int tokenLimit,
-        ISemanticTextMemory textMemory)
+        ISemanticTextMemory textMemory,
+        CancellationToken cancellationToken = default)
     {
         var remainingToken = tokenLimit;
 
@@ -76,7 +79,8 @@ public class DocumentMemorySkill
                     documentCollection,
                     query,
                     limit: 100,
-                    minRelevanceScore: this._promptOptions.DocumentMemoryMinRelevance);
+                    minRelevanceScore: this._promptOptions.DocumentMemoryMinRelevance,
+                    cancellationToken: cancellationToken);
                 await foreach (var memory in results)
                 {
                     relevantMemories.Add(memory);

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -12,7 +12,7 @@
 {
   //
   // Service configuration
-  // - Optionally set TimeoutLimit to the maximum number of seconds to wait for a response from the AI service.
+  // - Optionally set TimeoutLimitInS to the maximum number of seconds to wait for a response from the AI service. If this is not set, there is no timeout.
   // - Optionally set SemanticSkillsDirectory to the directory from which to load semantic skills (e.g., "./SemanticSkills").
   // - Optionally set KeyVaultUri to the URI of the Key Vault for secrets (e.g., "https://contoso.vault.azure.net/").
   //

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -12,10 +12,12 @@
 {
   //
   // Service configuration
+  // - Optionally set TimeoutLimit to the maximum number of seconds to wait for a response from the AI service.
   // - Optionally set SemanticSkillsDirectory to the directory from which to load semantic skills (e.g., "./SemanticSkills").
   // - Optionally set KeyVaultUri to the URI of the Key Vault for secrets (e.g., "https://contoso.vault.azure.net/").
   //
   "Service": {
+    // "TimeoutLimitInS": "120"
     // "SemanticSkillsDirectory": "",
     // "KeyVault": ""
   },

--- a/webapp/src/libs/services/BaseService.ts
+++ b/webapp/src/libs/services/BaseService.ts
@@ -48,6 +48,11 @@ export class BaseService {
 
             if (!response.ok) {
                 const responseText = await response.text();
+
+                if (response.status === 408) {
+                    throw Object.assign(new Error('The request timed out. Please try sending your message again.'));
+                }
+
                 const errorMessage = `${response.status}: ${response.statusText}${
                     responseText ? ` => ${responseText}` : ''
                 }`;

--- a/webapp/src/libs/services/BaseService.ts
+++ b/webapp/src/libs/services/BaseService.ts
@@ -49,7 +49,7 @@ export class BaseService {
             if (!response.ok) {
                 const responseText = await response.text();
 
-                if (response.status === 408) {
+                if (response.status === 504) {
                     throw Object.assign(new Error('The request timed out. Please try sending your message again.'));
                 }
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR adds a TimeoutLimitInS option in appsettings, which is used as the CancellationToken timeout if specified. The CancellationToken is used to monitor for cancellation requests.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

This PR fixes a bug by passing the cancellation token to all async methods of ChatSkill. If a timeout limit is not specified in appsettings, a cancellation token source without a timeout is created and passed.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
