### PR TITLE
Add check on backend being up before frontend command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ These quick-start instructions run the sample locally. To deploy the sample to A
 
 You will need the following items to run the sample:
 
-- [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0) _(via Setup script)_
-- [Node.js](https://nodejs.org/en/download) _(via Setup script)_
-- [Yarn](https://classic.yarnpkg.com/docs/install) _(via Setup script)_
+- [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0) _(via Setup install.* script)_
+- [Node.js](https://nodejs.org/en/download) _(via Setup install.*  script)_
+- [Yarn](https://classic.yarnpkg.com/docs/install) _(via Setup install.*  script)_
 - AI Service
 
 | AI Service   | Requirement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |

--- a/scripts/Start.ps1
+++ b/scripts/Start.ps1
@@ -8,6 +8,12 @@ $FrontendScript = Join-Path "$PSScriptRoot" 'Start-Frontend.ps1'
 
 # Start backend (in new PS process)
 Start-Process pwsh -ArgumentList "-command $BackendScript"
+#check if the backend is running before proceeding
+$backendRunning = $false
+while ($backendRunning -eq $false) {
+  $backendRunning = Test-NetConnection -ComputerName localhost -Port 40443 -InformationLevel Quiet
+  Start-Sleep -Seconds 5
+}
 
 # Start frontend (in current PS process)
 & $FrontendScript


### PR DESCRIPTION
### Motivation and Context

I noted that when running the Start.ps1 the backend would not be running via `Start-Process pwsh -ArgumentList "-command $BackendScript"` before the frontend command `& $FrontendScript`. I added a condition to check that the backend is running before starting the frontend process.

### Description

I added a condition to check that the backend is running before starting the frontend process.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x ] The code builds clean without any errors or warnings
- [x ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x ] I didn't break anyone :smile:
