### PR TITLE
Adding option for plugin timeout + using proper userId for guest accounts

### DIFF
--- a/webapi/Options/PlannerOptions.cs
+++ b/webapi/Options/PlannerOptions.cs
@@ -50,7 +50,7 @@ public class PlannerOptions
 
     /// <summary>
     /// The maximum number of seconds to wait for a response from a plugin.
-    /// If this is not set, timeout limit will be 100s, which is default timeout setting for HttpClient.
+    /// If this is not set, timeout limit will be 100s, which is the default timeout setting for HttpClient.
     /// </summary>
     [Range(0, int.MaxValue)]
     public double PluginTimeoutLimitInS { get; set; } = 100;

--- a/webapi/Options/PlannerOptions.cs
+++ b/webapi/Options/PlannerOptions.cs
@@ -49,6 +49,13 @@ public class PlannerOptions
     public double? RelevancyThreshold { get; set; } = 0;
 
     /// <summary>
+    /// The maximum number of seconds to wait for a response from a plugin.
+    /// If this is not set, timeout limit will be 100s, which is default timeout setting for HttpClient.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public double PluginTimeoutLimitInS { get; set; } = 100;
+
+    /// <summary>
     /// Options on how to handle planner errors.
     /// </summary>
     public ErrorOptions ErrorHandling { get; set; } = new ErrorOptions();

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -73,9 +73,12 @@
       "AllowMissingFunctions": "true",
       "MaxRetriesAllowed": "3" // Max retries allowed. If set to 0, no retries will be attempted.
     },
+    // The maximum number of seconds to wait for a response from a plugin. If this is not set, timeout limit will be 100s, which is default timeout setting for HttpClient
+    // Note: The Service:TimeoutLimitinS option above will take precendence on the broader request lifespan if set.
+    "PluginTimeoutLimitInS": 100, 
     "StepwisePlannerConfig": {
       "MaxTokens": "2048",
-      "MaxIterations": "15",
+      "MaxIterations": "10",
       "MinIterationTimeMs": "1500"
     }
   },

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -74,11 +74,11 @@
       "MaxRetriesAllowed": "3" // Max retries allowed. If set to 0, no retries will be attempted.
     },
     // The maximum number of seconds to wait for a response from a plugin. If this is not set, timeout limit will be 100s, which is default timeout setting for HttpClient
-    // Note: The Service:TimeoutLimitinS option above will take precendence on the broader request lifespan if set.
+    // Note: The Service:TimeoutLimitinS option above will take precedence on the broader request lifespan if set.
     "PluginTimeoutLimitInS": 100, 
     "StepwisePlannerConfig": {
       "MaxTokens": "2048",
-      "MaxIterations": "10",
+      "MaxIterations": "15",
       "MinIterationTimeMs": "1500"
     }
   },

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -79,8 +79,8 @@ const App: FC = () => {
                     } else {
                         dispatch(
                             setActiveUserInfo({
-                                id: account.homeAccountId,
-                                email: account.username, // username in an AccountInfo object is the email address
+                                id: `${account.localAccountId}.${account.tenantId}`,
+                                email: account.username, // Username in an AccountInfo object is the email address
                                 username: account.name ?? account.username,
                             }),
                         );


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Two small changes in this PR:
1. Using `${account.localAccountId}.${account.tenantId}` over account.homeAccountId to match how UserId is constructed for chat messages in webapi. 
2. Adds another option in appsettings to allow users to set a timeout limit for plugin calls. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

1. How userId is constructed in webapi:
![image](https://github.com/microsoft/chat-copilot/assets/125500434/d23c9544-6bb4-484c-b6ad-ce48ed891474)
-  `${account.localAccountId}.${account.tenantId}` is more accurate for guest accounts, and it is not equivalent to the homeAccountid (which = `{userIdInHomeTenant}.{HomeTenantId}` for guest accounts).
2. Default HttpClient.Timeout is 100 seconds; customer request to allow this to be configurable to accomodate plugins that take a long time.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
