### PR TITLE
Fix multi-user chat feature toggle behavior

### DIFF
--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -187,9 +187,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                             setValue((chatInput as HTMLTextAreaElement).value);
                         }
                         // User is considered typing if the input is in focus
-                        dispatch(
-                            updateUserIsTyping({ userId: activeUserInfo?.id, chatId: selectedId, isTyping: true }),
-                        );
+                        if (activeUserInfo) {
+                            dispatch(
+                                updateUserIsTyping({ userId: activeUserInfo.id, chatId: selectedId, isTyping: true }),
+                            );
+                        }
                     }}
                     onChange={(_event, data) => {
                         if (isDraggingOver) {
@@ -207,9 +209,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                     }}
                     onBlur={() => {
                         // User is considered not typing if the input is not  in focus
-                        dispatch(
-                            updateUserIsTyping({ userId: activeUserInfo?.id, chatId: selectedId, isTyping: false }),
-                        );
+                        if (activeUserInfo) {
+                            dispatch(
+                                updateUserIsTyping({ userId: activeUserInfo.id, chatId: selectedId, isTyping: false }),
+                            );
+                        }
                     }}
                 />
             </div>

--- a/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -133,18 +133,25 @@ export const ChatList: FC = () => {
 
     useEffect(() => {
         // Ensure local component state is in line with app state.
+        const nonHiddenConversations: Conversations = {};
+        for (const key in conversations) {
+            if (!conversations[key].hidden) {
+                nonHiddenConversations[key] = conversations[key];
+            }
+        }
+
         if (filterText !== '') {
             // Reapply search string to the updated conversations list.
             const filteredConversations: Conversations = {};
-            for (const key in conversations) {
-                if (conversations[key].title.toLowerCase().includes(filterText.toLowerCase())) {
-                    filteredConversations[key] = conversations[key];
+            for (const key in nonHiddenConversations) {
+                if (nonHiddenConversations[key].title.toLowerCase().includes(filterText.toLowerCase())) {
+                    filteredConversations[key] = nonHiddenConversations[key];
                 }
             }
             setConversationsView({ filteredConversations: filteredConversations });
         } else {
             // If no search string, show full conversations list.
-            setConversationsView(sortConversations(conversations));
+            setConversationsView(sortConversations(nonHiddenConversations));
         }
     }, [conversations, filterText]);
 

--- a/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -133,26 +133,15 @@ export const ChatList: FC = () => {
 
     useEffect(() => {
         // Ensure local component state is in line with app state.
-        const nonHiddenConversations: Conversations = {};
+        const filteredConversations: Conversations = {};
         for (const key in conversations) {
-            if (!conversations[key].hidden) {
-                nonHiddenConversations[key] = conversations[key];
+            const conversation = conversations[key];
+            if (!conversation.hidden && (!filterText || conversation.title.toLowerCase().includes(filterText))) {
+                filteredConversations[key] = conversation;
             }
         }
 
-        if (filterText !== '') {
-            // Reapply search string to the updated conversations list.
-            const filteredConversations: Conversations = {};
-            for (const key in nonHiddenConversations) {
-                if (nonHiddenConversations[key].title.toLowerCase().includes(filterText.toLowerCase())) {
-                    filteredConversations[key] = nonHiddenConversations[key];
-                }
-            }
-            setConversationsView({ filteredConversations: filteredConversations });
-        } else {
-            // If no search string, show full conversations list.
-            setConversationsView(sortConversations(nonHiddenConversations));
-        }
+        setConversationsView(sortConversations(filteredConversations));
     }, [conversations, filterText]);
 
     const onFilterClick = () => {

--- a/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -133,15 +133,15 @@ export const ChatList: FC = () => {
 
     useEffect(() => {
         // Ensure local component state is in line with app state.
-        const filteredConversations: Conversations = {};
+        const nonHiddenConversations: Conversations = {};
         for (const key in conversations) {
             const conversation = conversations[key];
             if (!conversation.hidden && (!filterText || conversation.title.toLowerCase().includes(filterText))) {
-                filteredConversations[key] = conversation;
+                nonHiddenConversations[key] = conversation;
             }
         }
 
-        setConversationsView(sortConversations(filteredConversations));
+        setConversationsView(sortConversations(nonHiddenConversations));
     }, [conversations, filterText]);
 
     const onFilterClick = () => {

--- a/webapp/src/components/header/settings-dialog/SettingSection.tsx
+++ b/webapp/src/components/header/settings-dialog/SettingSection.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from '../../../redux/app/hooks';
 import { RootState } from '../../../redux/app/store';
 import { FeatureKeys, Setting } from '../../../redux/features/app/AppState';
 import { toggleFeatureFlag } from '../../../redux/features/app/appSlice';
+import { toggleMultiUserConversations } from '../../../redux/features/conversations/conversationsSlice';
 
 const useClasses = makeStyles({
     feature: {
@@ -30,6 +31,9 @@ export const SettingSection: React.FC<ISettingsSectionProps> = ({ setting, conte
     const onFeatureChange = useCallback(
         (featureKey: FeatureKeys) => {
             dispatch(toggleFeatureFlag(featureKey));
+            if (featureKey === FeatureKeys.MultiUserChat) {
+                dispatch(toggleMultiUserConversations({}));
+            }
         },
         [dispatch],
     );

--- a/webapp/src/components/header/settings-dialog/SettingSection.tsx
+++ b/webapp/src/components/header/settings-dialog/SettingSection.tsx
@@ -32,7 +32,7 @@ export const SettingSection: React.FC<ISettingsSectionProps> = ({ setting, conte
         (featureKey: FeatureKeys) => {
             dispatch(toggleFeatureFlag(featureKey));
             if (featureKey === FeatureKeys.MultiUserChat) {
-                dispatch(toggleMultiUserConversations({}));
+                dispatch(toggleMultiUserConversations());
             }
         },
         [dispatch],

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -90,6 +90,7 @@ export const useChat = () => {
                         botResponseStatus: undefined,
                         userDataLoaded: false,
                         disabled: false,
+                        hidden: false,
                     };
 
                     dispatch(addConversation(newChat));
@@ -149,13 +150,8 @@ export const useChat = () => {
             if (chatSessions.length > 0) {
                 const loadedConversations: Conversations = {};
                 for (const chatSession of chatSessions) {
-                    const chatMessages = await chatService.getChatMessagesAsync(chatSession.id, 0, 100, accessToken);
-
                     const chatUsers = await chatService.getAllChatParticipantsAsync(chatSession.id, accessToken);
-
-                    if (!features[FeatureKeys.MultiUserChat].enabled && chatUsers.length > 1) {
-                        continue;
-                    }
+                    const chatMessages = await chatService.getChatMessagesAsync(chatSession.id, 0, 100, accessToken);
 
                     loadedConversations[chatSession.id] = {
                         id: chatSession.id,
@@ -169,11 +165,19 @@ export const useChat = () => {
                         botResponseStatus: undefined,
                         userDataLoaded: false,
                         disabled: false,
+                        hidden: !features[FeatureKeys.MultiUserChat].enabled && chatUsers.length > 1,
                     };
                 }
 
                 dispatch(setConversations(loadedConversations));
-                dispatch(setSelectedConversation(chatSessions[0].id));
+
+                // If there are no non-hidden chats, create a new chat
+                const nonHiddenChats = Object.values(loadedConversations).filter((c) => !c.hidden);
+                if (nonHiddenChats.length === 0) {
+                    await createChat();
+                } else {
+                    dispatch(setSelectedConversation(nonHiddenChats[0].id));
+                }
             } else {
                 // No chats exist, create first chat window
                 await createChat();
@@ -315,6 +319,7 @@ export const useChat = () => {
                     botResponseStatus: undefined,
                     userDataLoaded: false,
                     disabled: false,
+                    hidden: false,
                 };
 
                 dispatch(addConversation(newChat));

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -212,10 +212,16 @@ export const useChat = () => {
                 const newChat = {
                     id: chatSession.id,
                     title: chatSession.title,
+                    systemDescription: chatSession.systemDescription,
+                    memoryBalance: chatSession.memoryBalance,
                     users: [loggedInUser],
                     messages: chatMessages,
                     botProfilePicture: getBotProfilePicture(Object.keys(conversations).length),
+                    input: '',
                     botResponseStatus: undefined,
+                    userDataLoaded: false,
+                    disabled: false,
+                    hidden: false,
                 };
 
                 dispatch(addConversation(newChat));

--- a/webapp/src/redux/features/conversations/ChatState.ts
+++ b/webapp/src/redux/features/conversations/ChatState.ts
@@ -16,5 +16,6 @@ export interface ChatState {
     botResponseStatus: string | undefined;
     userDataLoaded: boolean;
     importingDocuments?: string[];
-    disabled: boolean;
+    disabled: boolean; // For labeling a chat has been deleted
+    hidden: boolean; // For hiding a chat from the list
 }

--- a/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ChatMessageType, IChatMessage, UserFeedback } from '../../../libs/models/ChatMessage';
 import { IChatUser } from '../../../libs/models/ChatUser';
 import { ChatState } from './ChatState';
@@ -13,7 +13,7 @@ import {
     initialState,
 } from './ConversationsState';
 
-export const conversationsSlice: Slice<ConversationsState> = createSlice({
+export const conversationsSlice = createSlice({
     name: 'conversations',
     initialState,
     reducers: {
@@ -127,7 +127,7 @@ export const conversationsSlice: Slice<ConversationsState> = createSlice({
         },
         updateBotResponseStatus: (
             state: ConversationsState,
-            action: PayloadAction<{ chatId: string; status: string }>,
+            action: PayloadAction<{ chatId: string; status: string | undefined }>,
         ) => {
             const { chatId, status } = action.payload;
             const conversation = state.conversations[chatId];

--- a/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -50,6 +50,14 @@ export const conversationsSlice: Slice<ConversationsState> = createSlice({
         setSelectedConversation: (state: ConversationsState, action: PayloadAction<string>) => {
             state.selectedId = action.payload;
         },
+        toggleMultiUserConversations: (state: ConversationsState) => {
+            const keys = Object.keys(state.conversations);
+            keys.forEach((key) => {
+                if (state.conversations[key].users.length > 1) {
+                    state.conversations[key].hidden = !state.conversations[key].hidden;
+                }
+            });
+        },
         addConversation: (state: ConversationsState, action: PayloadAction<ChatState>) => {
             const newId = action.payload.id;
             state.conversations = { [newId]: action.payload, ...state.conversations };
@@ -209,6 +217,7 @@ export const {
     editConversationSystemDescription,
     editConversationMemoryBalance,
     setSelectedConversation,
+    toggleMultiUserConversations,
     addConversation,
     setImportingDocumentsToConversation,
     addMessageToConversationFromUser,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
A couple of issues:
1. Multi-user chat sessions are filtered out in the loadChats method if the feature is disabled. When the feature is enabled, it doesn't call loadChats again, making it impossible to retrieve multi-user chat sessions. 
2. Supposed a user has only multi-user chat session, when the app first starts, all the multi-user chat sessions will be filtered out but the app doesn't call create chat, leaving the user with no chat to interact with.
3. the initial selectedId is the id of the first chat session returned by the service. If the first chat session is a multi-user chat session, the app will crash because the first chat session is filtered out and the selectedId becomes invalid.

### Description
Address all the above.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
