### PR TITLE
Fix Exception catch block for vector-storage connector

### DIFF
--- a/webapi/Controllers/BotController.cs
+++ b/webapi/Controllers/BotController.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 
 namespace CopilotChat.WebApi.Controllers;
@@ -209,6 +208,7 @@ public class BotController : ControllerBase
         string? newCollectionName = null)
     {
         List<MemoryQueryResult> collectionMemoryRecords;
+#pragma warning disable CA1031 // Each connector may throw different exception type
         try
         {
             collectionMemoryRecords = await kernel.Memory.SearchAsync(
@@ -220,7 +220,7 @@ public class BotController : ControllerBase
                 cancellationToken: default
             ).ToListAsync();
         }
-        catch (SKException connectorException)
+        catch (Exception connectorException)
         {
             // A store exception might be thrown if the collection does not exist, depending on the memory store connector.
             this._logger.LogError(connectorException,
@@ -228,6 +228,7 @@ public class BotController : ControllerBase
                 collectionName);
             collectionMemoryRecords = new();
         }
+#pragma warning restore CA1031 // Each connector may throw different exception type
 
         embeddings.Add(new KeyValuePair<string, List<MemoryQueryResult>>(
             string.IsNullOrEmpty(newCollectionName) ? collectionName : newCollectionName,

--- a/webapi/Controllers/ChatMemoryController.cs
+++ b/webapi/Controllers/ChatMemoryController.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 
 namespace CopilotChat.WebApi.Controllers;
@@ -86,6 +85,7 @@ public class ChatMemoryController : ControllerBase
         // minRelevanceScore is set to 0.0 to return all memories.
         List<string> memories = new();
         string memoryCollectionName = SemanticChatMemoryExtractor.MemoryCollectionName(sanitizedChatId, sanitizedMemoryName);
+#pragma warning disable CA1031 // Each connector may throw different exception type
         try
         {
             var results = semanticTextMemory.SearchAsync(
@@ -98,12 +98,13 @@ public class ChatMemoryController : ControllerBase
                 memories.Add(memory.Metadata.Text);
             }
         }
-        catch (SKException connectorException)
+        catch (Exception connectorException)
         {
             // A store exception might be thrown if the collection does not exist, depending on the memory store connector.
             var sanitizedMemoryCollectionName = memoryCollectionName.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
             this._logger.LogError(connectorException, "Cannot search collection {0}", sanitizedMemoryCollectionName);
         }
+#pragma warning restore CA1031 // Each connector may throw different exception type
 
         return this.Ok(memories);
     }

--- a/webapi/Skills/ChatSkills/DocumentMemorySkill.cs
+++ b/webapi/Skills/ChatSkills/DocumentMemorySkill.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -8,7 +9,6 @@ using System.Threading.Tasks;
 using CopilotChat.WebApi.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.SkillDefinition;
 
@@ -73,6 +73,7 @@ public class DocumentMemorySkill
         List<MemoryQueryResult> relevantMemories = new();
         foreach (var documentCollection in documentCollections)
         {
+#pragma warning disable CA1031 // Each connector may throw different exception type
             try
             {
                 var results = textMemory.SearchAsync(
@@ -86,11 +87,12 @@ public class DocumentMemorySkill
                     relevantMemories.Add(memory);
                 }
             }
-            catch (SKException connectorException)
+            catch (Exception connectorException)
             {
                 // A store exception might be thrown if the collection does not exist, depending on the memory store connector.
                 this._logger.LogError(connectorException, "Cannot search collection {0}", documentCollection);
             }
+#pragma warning restore CA1031 // Each connector may throw different exception type
         }
 
         relevantMemories = relevantMemories.OrderByDescending(m => m.Relevance).ToList();

--- a/webapi/Skills/ChatSkills/SemanticChatMemoryExtractor.cs
+++ b/webapi/Skills/ChatSkills/SemanticChatMemoryExtractor.cs
@@ -10,7 +10,6 @@ using CopilotChat.WebApi.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.TextCompletion;
-using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 
@@ -141,6 +140,7 @@ internal static class SemanticChatMemoryExtractor
     {
         var memoryCollectionName = SemanticChatMemoryExtractor.MemoryCollectionName(chatId, memoryName);
 
+#pragma warning disable CA1031 // Each connector may throw different exception type
         try
         {
             // Search if there is already a memory item that has a high similarity score with the new item.
@@ -165,11 +165,12 @@ internal static class SemanticChatMemoryExtractor
                 );
             }
         }
-        catch (SKException connectorException)
+        catch (Exception connectorException)
         {
             // A store exception might be thrown if the collection does not exist, depending on the memory store connector.
             logger.LogError(connectorException, "Cannot search collection {0}", memoryCollectionName);
         }
+#pragma warning restore CA1031 // Each connector may throw different exception type
     }
 
     /// <summary>

--- a/webapi/Skills/ChatSkills/SemanticChatMemorySkill.cs
+++ b/webapi/Skills/ChatSkills/SemanticChatMemorySkill.cs
@@ -11,7 +11,6 @@ using CopilotChat.WebApi.Options;
 using CopilotChat.WebApi.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.SkillDefinition;
 
@@ -71,6 +70,7 @@ public class SemanticChatMemorySkill
         foreach (var memoryName in this._promptOptions.MemoryMap.Keys)
         {
             string memoryCollectionName = SemanticChatMemoryExtractor.MemoryCollectionName(chatId, memoryName);
+#pragma warning disable CA1031 // Each connector may throw different exception type
             try
             {
                 var results = textMemory.SearchAsync(
@@ -84,11 +84,12 @@ public class SemanticChatMemorySkill
                     relevantMemories.Add(memory);
                 }
             }
-            catch (SKException connectorException)
+            catch (Exception connectorException)
             {
                 // A store exception might be thrown if the collection does not exist, depending on the memory store connector.
                 this._logger.LogError(connectorException, "Cannot search collection {0}", memoryCollectionName);
             }
+#pragma warning restore CA1031 // Each connector may throw different exception type
         }
 
         relevantMemories = relevantMemories.OrderByDescending(m => m.Relevance).ToList();


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Customer discovered this issue today and it will block anyone who tries to create a new chat.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

SK used to throw SKException.  Now they are allowing an Azure specific excepetion type to bubble-up for ACS connector and could be anything for different connectors.

This is exacerbated by a second latent SK behavior that a vector-database container/index requires a write before allowing a successful (non-exceptional) read.  Previously chat-copilot was catching these exceptions as SKException.  Now they are uncaught.  This change fixes that.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
