### PR TITLE
Update sub-readmes for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ You will need the following items to run the sample:
 
    > NOTE: Confirm pop-ups are not blocked and you are logged in with the same account used to register the application.
 
+   - (Optional) Start ONLY the backend:
+  
+     ```powershell
+     .\Start-Backend.ps1
+     ```
+
+
 ## Linux/macOS
 
 1. Open Bash as an administrator.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You will need the following items to run the sample:
    > NOTE: Confirm pop-ups are not blocked and you are logged in with the same account used to register the application.
 
    - (Optional) To start ONLY the backend:
-  
+
      ```powershell
      .\Start-Backend.ps1
      ```
@@ -143,6 +143,12 @@ You will need the following items to run the sample:
    It may take a few minutes for Yarn packages to install on the first run.
 
    > NOTE: Confirm pop-ups are not blocked and you are logged in with the same account used to register the application.
+
+   - (Optional) To start ONLY the backend:
+
+     ```powershell
+     ./start-backend.sh
+     ```
 
 ## (Optional) Enable backend authentication via Azure AD
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This sample allows you to build your own integrated large language model (LLM) chat copilot. The sample is built on Microsoft [Semantic Kernel](https://github.com/microsoft/semantic-kernel) and has two components: a frontend [React web app](./webapp/) and a backend [.NET web API service](./webapi/).
 
-These quick-start instructions run the sample locally. To deploy the sample to Azure, please view [Deploying Chat Copilot](./scripts/deploy/README.md) after meeting the [requirements](#requirements) described below.
+These quick-start instructions run the sample locally. They can also be found on the official Chat Copilot Microsoft Learn documentation page for [getting started](https://learn.microsoft.com/semantic-kernel/chat-copilot/getting-started).
+
+To deploy the sample to Azure, please view [Deploying Chat Copilot](./scripts/deploy/README.md) after meeting the [requirements](#requirements) described below.
 
 > **IMPORTANT:** This sample is for educational purposes only and is not recommended for production deployments.
 
@@ -66,7 +68,7 @@ You will need the following items to run the sample:
 
    > NOTE: Confirm pop-ups are not blocked and you are logged in with the same account used to register the application.
 
-   - (Optional) Start ONLY the backend:
+   - (Optional) To start ONLY the backend:
   
      ```powershell
      .\Start-Backend.ps1
@@ -330,7 +332,7 @@ Bug reports and fixes are welcome!
 
 To learn more and get started:
 
-- Read the [documentation](https://learn.microsoft.com/en-us/semantic-kernel/chat-copilot/)
+- Read the [documentation](https://learn.microsoft.com/semantic-kernel/chat-copilot/)
 - Join the [Discord community](https://aka.ms/SKDiscord)
 - [Contribute](CONTRIBUTING.md) to the project
 - Follow the team on our [blog](https://aka.ms/sk/blog)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ You will need the following items to run the sample:
      .\Start-Backend.ps1
      ```
 
-
 ## Linux/macOS
 
 1. Open Bash as an administrator.

--- a/webapi/README.md
+++ b/webapi/README.md
@@ -1,64 +1,12 @@
-# Copilot Chat Web API
+# Chat Copilot backend web API service
 
-This ASP.Net web application provides a web service hosting the [Semantic Kernel](https://github.com/microsoft/semantic-kernel), enabling secure
-and modular access to its features for the Copilot Chat application without embedding kernel code and settings,
-while allowing user interfaces to be developed using frontend frameworks such as React and Angular.
+This directory contains the source code for Chat Copilot's backend web API service. The front end web application component can be found in the [webapp/](./webapp/) directory.
 
-# Configure your environment
+## Running the Chat Copilot sample
+To configure and run either the full Chat Copilot application or only the backend API, please view the [main instructions](../README.md#instructions).
 
-Before you get started, make sure you have the following requirements in place:
-
-1. [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) for building and deploying .NET 6 projects.
-2. **(Optional)** [Visual Studio Code](http://aka.ms/vscode) or [Visual Studio](http://aka.ms/vsdownload).
-3. Update the properties in `./appsettings.json` to configure your Azure OpenAI resource or OpenAI account.
-4. Generate and trust a localhost developer certificate.
-
-   - For Windows and Mac run
-     ```bash
-     dotnet dev-certs https --trust
-     ```
-     > Select `Yes` when asked if you want to install this certificate.
-   - For Linux run
-     ```bash
-     dotnet dev-certs https
-     ```
-
-   > To verify the certificate has been installed and trusted, run `dotnet run dev-certs https --check`
-
-   > To clean your system of the developer certificate, run `dotnet run dev-certs https --clean`
-
-5. **(Optional)** To enable support for uploading image file formats such as png, jpg and tiff, there are two options within the `OcrSupport` section of `./appsettings.json`, the Tesseract open source library and Azure Form Recognizer.
-   - **Tesseract** we have included the [Tesseract](https://www.nuget.org/packages/Tesseract) nuget package.
-     - You will need to obtain one or more [tessdata language data files](https://github.com/tesseract-ocr/tessdata) such as `eng.traineddata` and add them to your `./data` directory or the location specified in the `OcrSupport:Tesseract:FilePath` location in `./appsettings.json`.
-     - Set the `Copy to Output Directory` value to `Copy if newer`.
-   - **Azure Form Recognizer** we have included the [Azure.AI.FormRecognizer](https://www.nuget.org/packages/Azure.AI.FormRecognizer) nuget package.
-     - You will need to obtain an [Azure Form Recognizer](https://azure.microsoft.com/en-us/services/form-recognizer/) resource and add the `OcrSupport:AzureFormRecognizer:Endpoint` and `OcrSupport:AzureFormRecognizer:Key` values to the `./appsettings.json` file.
-
-# Start the WebApi Service
-
-You can start the WebApi service using the command-line, Visual Studio Code, or Visual Studio.
-
-## Command-line
-
-1. Open a terminal
-2. Change directory to the Copilot Chat webapi project directory.
-   ```
-   cd webapi/
-   ```
-3. (Optional) Build the service and verify there are no errors.
-   ```
-   dotnet build
-   ```
-4. Run the service
-   ```
-   dotnet run
-   ```
-5. Early in the startup, the service will provide a probe endpoint you can use in a web browser to verify
-   the service is running.
-   ```
-   info: Microsoft.SemanticKernel.Kernel[0]
-         Health probe: https://localhost:40443/healthz
-   ```
+# (Under Development)
+The following material is under development and may not be complete or accurate.
 
 ## Visual Studio Code
 
@@ -72,7 +20,15 @@ You can start the WebApi service using the command-line, Visual Studio Code, or 
 2. In Solution Explorer, right-click on `CopilotChatWebApi` and select `Set as Startup Project`.
 3. Start debugging by pressing `F5` or selecting the menu item `Debug`->`Start Debugging`.
 
-# Enabling Sequential Planner
+1. **(Optional)** To enable support for uploading image file formats such as png, jpg and tiff, there are two options within the `OcrSupport` section of `./appsettings.json`, the Tesseract open source library and Azure Form Recognizer.
+   - **Tesseract** we have included the [Tesseract](https://www.nuget.org/packages/Tesseract) nuget package.
+     - You will need to obtain one or more [tessdata language data files](https://github.com/tesseract-ocr/tessdata) such as `eng.traineddata` and add them to your `./data` directory or the location specified in the `OcrSupport:Tesseract:FilePath` location in `./appsettings.json`.
+     - Set the `Copy to Output Directory` value to `Copy if newer`.
+   - **Azure Form Recognizer** we have included the [Azure.AI.FormRecognizer](https://www.nuget.org/packages/Azure.AI.FormRecognizer) nuget package.
+     - You will need to obtain an [Azure Form Recognizer](https://azure.microsoft.com/en-us/services/form-recognizer/) resource and add the `OcrSupport:AzureFormRecognizer:Endpoint` and `OcrSupport:AzureFormRecognizer:Key` values to the `./appsettings.json` file.
+
+
+## Enabling Sequential Planner
 
 If you want to use SequentialPlanner (multi-step) instead ActionPlanner (single-step), we recommend using `gpt-4` or `gpt-3.5-turbo` as the planner model. **SequentialPlanner works best with `gpt-4`.** Using `gpt-3.5-turbo` will require using a relevancy filter.
 
@@ -93,20 +49,20 @@ To enable sequential planner,
         \* The `RelevancyThreshold` is a number from 0 to 1 that represents how similar a goal is to a function's name/description/inputs. You want to tune that value when using SequentialPlanner to help keep things scoped while not missing on on things that are relevant or including too many things that really aren't. `0.75` is an arbitrary threshold and we recommend developers play around with this number to see what best fits their scenarios.
 1. Restart the `webapi` - Copilot Chat should be now running locally with SequentialPlanner.
 
-# (Optional) Enabling the Qdrant Memory Store
+## (Optional) Enabling the Qdrant Memory Store
 
 By default, the service uses an in-memory volatile memory store that, when the service stops or restarts, forgets all memories.
 [Qdrant](https://github.com/qdrant/qdrant) is a persistent scalable vector search engine that can be deployed locally in a container or [at-scale in the cloud](https://github.com/Azure-Samples/qdrant-azure).
 
 To enable the Qdrant memory store, you must first deploy Qdrant locally and then configure the Copilot Chat API service to use it.
 
-## 1. Configure your environment
+### 1. Configure your environment
 
 Before you get started, make sure you have the following additional requirements in place:
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop) for hosting the [Qdrant](https://github.com/qdrant/qdrant) vector search engine.
 
-## 2. Deploy Qdrant VectorDB locally
+### 2. Deploy Qdrant VectorDB locally
 
 1. Open a terminal and use Docker to pull down the container image.
 
@@ -124,12 +80,12 @@ Before you get started, make sure you have the following additional requirements
 
    > To stop the container, in another terminal window run `docker container stop copilotchat; docker container rm copilotchat;`.
 
-# (Optional) Enabling the Azure Cognitive Search Memory Store
+## (Optional) Enabling the Azure Cognitive Search Memory Store
 
 Azure Cognitive Search can be used as a persistent memory store for Copilot Chat.
 The service uses its [vector search](https://learn.microsoft.com/en-us/azure/search/vector-search-overview) capabilities.
 
-# (Optional) Enable Application Insights telemetry
+## (Optional) Enable Application Insights telemetry
 
 Enabling telemetry on CopilotChatApi allows you to capture data about requests to and from the API, allowing you to monitor the deployment and monitor how the application is being used.
 

--- a/webapi/README.md
+++ b/webapi/README.md
@@ -1,6 +1,6 @@
 # Chat Copilot backend web API service
 
-This directory contains the source code for Chat Copilot's backend web API service. The front end web application component can be found in the [webapp/](./webapp/) directory.
+This directory contains the source code for Chat Copilot's backend web API service. The front end web application component can be found in the [webapp/](../webapp/) directory.
 
 ## Running the Chat Copilot sample
 To configure and run either the full Chat Copilot application or only the backend API, please view the [main instructions](../README.md#instructions).

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,9 +1,12 @@
-# Copilot Chat Web App
+# Chat Copilot front end web application
 
-> This learning sample is for educational purposes only and is not recommended for
-> production deployments.
+This directory contains the source code for Chat Copilot's frontend web application. The backend web API service component can be found in the [webapi/](./webapi/) directory.
 
-See [../README.md](../README.md) for complete instructions on setting up and running the application.
+## Running the Chat Copilot sample
+To configure and run the full Chat Copilot application, please view the [main instructions](../README.md#instructions).
+
+# (Under Development)
+The following material is under development and may not be complete or accurate.
 
 ## How to use HTTPS for local development
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,6 +1,6 @@
 # Chat Copilot front end web application
 
-This directory contains the source code for Chat Copilot's frontend web application. The backend web API service component can be found in the [webapi/](./webapi/) directory.
+This directory contains the source code for Chat Copilot's frontend web application. The backend web API service component can be found in the [webapi/](../webapi/) directory.
 
 ## Running the Chat Copilot sample
 To configure and run the full Chat Copilot application, please view the [main instructions](../README.md#instructions).


### PR DESCRIPTION
### Motivation and Context

  1. Why is this change required? Confusion on getting-started abounds!
  2. What problem does it solve? sub-readmes provided inconsistent basic getting-started info.
  3. What scenario does it contribute to?  attempting to remove confusion around getting started
  4. If it fixes an open issue, please link to the issue here. https://github.com/microsoft/chat-copilot/issues/344

### Description

This removes duplicate or incomplete information from the sub-readmes in webapp/ and webapi/ on basic getting started.  It redirects users to the main instruction readme, and also points to the learn docs getting started guide (which should be the ONLY duplicate of these instructions).

This change does NOT:
- attempt to update detailed development or debug information on the backend.  That falls under a separate task.
- attempt to update the optional material.  This pre-existing material has not been tested and any updates fall under a separate task.
 
Therefore, there is an added "under development" section in the sub-readmes to alert readers on potentially remaining out-of-date material.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
