### PR TITLE
Remove unused webapi packages

### DIFF
--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Azure.AI.FormRecognizer" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.4" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="0.23.230906.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Planning.StepwisePlanner" Version="0.23.230906.2-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" Version="0.23.230906.2-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch" Version="0.23.230906.2-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Chroma" Version="0.23.230906.2-preview" />
@@ -21,13 +20,11 @@
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Postgres" Version="0.23.230906.2-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Skills.MsGraph" Version="0.23.230906.2-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Skills.OpenAPI" Version="0.23.230906.2-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Skills.Web" Version="0.23.230906.2-preview" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.13.4" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.3" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
upon testing the update to `System.IdentityModel.Tokens.Jwt` in #355, I noticed that the package, as well as 2 others, are unused.
### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- removes  `System.IdentityModel.Tokens.Jwt`, `Microsoft.SemanticKernel.Skills.Web`, and `Microsoft.SemanticKernel.Planning.StepwisePlanner`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
