### PR TITLE
Fix issue 378 to able to use scripts with spaces in full path

### DIFF
--- a/scripts/Start.ps1
+++ b/scripts/Start.ps1
@@ -3,11 +3,10 @@
 Initializes and runs both the backend and frontend for Chat Copilot.
 #>
 
-$BackendScript = Join-Path "$PSScriptRoot" 'Start-Backend.ps1'
 $FrontendScript = Join-Path "$PSScriptRoot" 'Start-Frontend.ps1'
 
 # Start backend (in new PS process)
-Start-Process pwsh -ArgumentList "-command $BackendScript"
+Start-Process powershell -WorkingDirectory "$PSScriptRoot" -ArgumentList '-NoExit -Command ".\`"Start-Backend.ps1""'
 # check if the backend is running before proceeding
 $backendRunning = $false
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. The backend not be able to start by execute Start.ps1 when there are spaces in repo path
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. (https://github.com/microsoft/chat-copilot/issues/378)
-->

### Description

Update the command to handle the spaces in path of backend script

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
