### PR TITLE
Add option to manually build memory pipeline executable

### DIFF
--- a/.github/workflows/copilot-build-memorypipeline.yml
+++ b/.github/workflows/copilot-build-memorypipeline.yml
@@ -1,6 +1,7 @@
 ﻿name: copilot-build-memorypipeline
 
 on:
+  workflow_dispatch:  
   pull_request:
     branches: ["main"]
     paths:


### PR DESCRIPTION
### Motivation and Context
Sometimes, we just want the memory pipeline executable without running the whole deployment pipeline.

### Description
Add option to manually build memory pipeline executable in GitHub workflow

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
