### PR TITLE
Deconfigure Memory Names (Only use predefined values)

### DIFF
--- a/webapi/Controllers/BotController.cs
+++ b/webapi/Controllers/BotController.cs
@@ -124,7 +124,7 @@ public class BotController : ControllerBase
             "GlobalDocuments",
             await this.GetMemoryRecordsAndAppendToEmbeddingsAsync(
                 Guid.Empty.ToString(),
-                this._promptOptions.DocumentMemoryName,
+                PromptsOptions.DocumentMemoryName,
                 cancellationToken));
 
         // get the document memory collection names (user scope)
@@ -132,7 +132,7 @@ public class BotController : ControllerBase
             "ChatDocuments",
             await this.GetMemoryRecordsAndAppendToEmbeddingsAsync(
                 chatIdString,
-                this._promptOptions.DocumentMemoryName,
+                PromptsOptions.DocumentMemoryName,
                 cancellationToken));
 
         return bot;

--- a/webapi/Controllers/DocumentController.cs
+++ b/webapi/Controllers/DocumentController.cs
@@ -225,7 +225,7 @@ public class DocumentController : ControllerBase
                         this._promptOptions.MemoryIndexName,
                         memorySource.Id,
                         chatId.ToString(),
-                        this._promptOptions.DocumentMemoryName,
+                        PromptsOptions.DocumentMemoryName,
                         formFile.FileName,
                         stream);
 

--- a/webapi/Options/PromptsOptions.cs
+++ b/webapi/Options/PromptsOptions.cs
@@ -90,7 +90,7 @@ public class PromptsOptions
     [Required, NotEmptyOrWhitespace] public string MemoryIndexName { get; set; } = string.Empty;
 
     // Document memory
-    [Required, NotEmptyOrWhitespace] public string DocumentMemoryName { get; set; } = string.Empty;
+    internal const string DocumentMemoryName = "DocumentMemory";
 
     // Memory extraction
     [Required, NotEmptyOrWhitespace] public string SystemCognitive { get; set; } = string.Empty;
@@ -99,13 +99,14 @@ public class PromptsOptions
     [Required, NotEmptyOrWhitespace] public string MemoryContinuation { get; set; } = string.Empty;
 
     // Long-term memory
-    [Required, NotEmptyOrWhitespace] public string LongTermMemoryName { get; set; } = string.Empty;
+    internal const string LongTermMemoryName = "LongTermMemory";
+
     [Required, NotEmptyOrWhitespace] public string LongTermMemoryExtraction { get; set; } = string.Empty;
 
     internal string[] LongTermMemoryPromptComponents => new string[]
     {
         this.SystemCognitive,
-        $"{this.LongTermMemoryName} Description:\n{this.LongTermMemoryExtraction}",
+        $"{LongTermMemoryName} Description:\n{this.LongTermMemoryExtraction}",
         this.MemoryAntiHallucination,
         $"Chat Description:\n{this.SystemDescription}",
         "{{ChatSkill.ExtractChatHistory}}",
@@ -115,13 +116,14 @@ public class PromptsOptions
     internal string LongTermMemory => string.Join("\n", this.LongTermMemoryPromptComponents);
 
     // Working memory
-    [Required, NotEmptyOrWhitespace] public string WorkingMemoryName { get; set; } = string.Empty;
+    internal const string WorkingMemoryName = "WorkingMemory";
+
     [Required, NotEmptyOrWhitespace] public string WorkingMemoryExtraction { get; set; } = string.Empty;
 
     internal string[] WorkingMemoryPromptComponents => new string[]
     {
         this.SystemCognitive,
-        $"{this.WorkingMemoryName} Description:\n{this.WorkingMemoryExtraction}",
+        $"{WorkingMemoryName} Description:\n{this.WorkingMemoryExtraction}",
         this.MemoryAntiHallucination,
         $"Chat Description:\n{this.SystemDescription}",
         "{{ChatSkill.ExtractChatHistory}}",
@@ -133,8 +135,8 @@ public class PromptsOptions
     // Memory map
     internal IDictionary<string, string> MemoryMap => new Dictionary<string, string>()
     {
-        { this.LongTermMemoryName, this.LongTermMemory },
-        { this.WorkingMemoryName, this.WorkingMemory }
+        { LongTermMemoryName, this.LongTermMemory },
+        { WorkingMemoryName, this.WorkingMemory }
     };
 
     // Chat commands

--- a/webapi/Skills/TokenUtilities.cs
+++ b/webapi/Skills/TokenUtilities.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using CopilotChat.WebApi.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
@@ -28,8 +29,8 @@ public static class TokenUtilities
         { "SystemIntentExtraction", "userIntentExtraction" },
         { "SystemMetaPrompt", "metaPromptTemplate" },
         { "SystemCompletion", "responseCompletion"},
-        { "SystemCognitive_WorkingMemory", "workingMemoryExtraction" },
-        { "SystemCognitive_LongTermMemory", "longTermMemoryExtraction" }
+        { $"SystemCognitive_{PromptsOptions.WorkingMemoryName}", "workingMemoryExtraction" },
+        { $"SystemCognitive_{PromptsOptions.LongTermMemoryName}", "longTermMemoryExtraction" }
     };
 
     /// <summary>

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -162,11 +162,8 @@
     "MemoryFormat": "{\"items\": [{\"label\": string, \"details\": string }]}",
     "MemoryAntiHallucination": "IMPORTANT: DO NOT INCLUDE ANY OF THE ABOVE INFORMATION IN THE GENERATED RESPONSE AND ALSO DO NOT MAKE UP OR INFER ANY ADDITIONAL INFORMATION THAT IS NOT INCLUDED BELOW. ALSO DO NOT RESPOND IF THE LAST MESSAGE WAS NOT ADDRESSED TO YOU.",
     "MemoryContinuation": "Generate a well-formed JSON of extracted context data. DO NOT include a preamble in the response. DO NOT give a list of possible responses. Only provide a single response of the json block.\nResponse:",
-    "WorkingMemoryName": "WorkingMemory",
     "WorkingMemoryExtraction": "Extract information for a short period of time, such as a few seconds or minutes. It should be useful for performing complex cognitive tasks that require attention, concentration, or mental calculation.",
-    "LongTermMemoryName": "LongTermMemory",
     "LongTermMemoryExtraction": "Extract information that is encoded and consolidated from other memory types, such as working memory or sensory memory. It should be useful for maintaining and recalling one's personal identity, history, and knowledge over time.",
-    "DocumentMemoryName": "DocumentMemory",
     "MemoryIndexName": "chatmemory"
   },
   // Filter for hostnames app can bind to


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Customer reported issue when changing memory names via config: https://github.com/microsoft/chat-copilot/issues/388

In  discussion with Ben, we wondered what is the point of allowing this to vary.  One impact is that someone can break themselves by changing config for an existing deployment.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Pin memory lables:

- WorkingMemory
- LongTermMemory
- DocumentMemory

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
