### PR TITLE
Stop adding "PR: ready for review" to all PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,7 +21,3 @@ documentation:
 # Add 'github actions' label to any change within the '.github/workflows' directory
 "github actions":
   - .github/workflows/**/*
-
-# Add 'PR: ready for review' label to all PRs
-"PR: ready for review":
-  - "**"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
this label will also be removed, since all PRs not marked in Draft should be ready to review.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
