### PR TITLE
Using semantic memory type enum instead of string in API contract.

### DIFF
--- a/webapi/Controllers/ChatMemoryController.cs
+++ b/webapi/Controllers/ChatMemoryController.cs
@@ -51,7 +51,7 @@ public class ChatMemoryController : ControllerBase
     /// </summary>
     /// <param name="semanticTextMemory">The semantic text memory instance.</param>
     /// <param name="chatId">The chat id.</param>
-    /// <param name="memoryType">Type of the memory type. Must map to a member of <see cref="SemanticMemoryType"/>.</param>
+    /// <param name="memoryType">Type of memory. Must map to a member of <see cref="SemanticMemoryType"/>.</param>
     [HttpGet]
     [Route("chatMemory/{chatId:guid}/{memoryType}")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/webapi/Controllers/ChatMemoryController.cs
+++ b/webapi/Controllers/ChatMemoryController.cs
@@ -66,8 +66,8 @@ public class ChatMemoryController : ControllerBase
         // https://github.com/microsoft/chat-copilot/security/code-scanning/1
         var sanitizedChatId = GetSanitizedParameter(chatId);
 
-        // Map the requested memorType to the memory store container name
-        if (!this._promptOptions.TryGetMemoryContainerName(memoryType, out string memoryConatinerName))
+        // Map the requested memoryType to the memory store container name
+        if (!this._promptOptions.TryGetMemoryContainerName(memoryType, out string memoryContainerName))
         {
             this._logger.LogWarning("Memory type: {0} is invalid.", memoryType);
             return this.BadRequest($"Memory type: {memoryType} is invalid.");
@@ -89,7 +89,7 @@ public class ChatMemoryController : ControllerBase
             // Search if there is already a memory item that has a high similarity score with the new item.
             var filter = new MemoryFilter();
             filter.ByTag("chatid", chatId);
-            filter.ByTag("memory", memoryConatinerName);
+            filter.ByTag("memory", memoryContainerName);
             filter.MinRelevance = 0;
 
             var searchResult =
@@ -99,7 +99,7 @@ public class ChatMemoryController : ControllerBase
                     relevanceThreshold: 0,
                     resultCount: 1,
                     chatId,
-                    memoryConatinerName)
+                    memoryContainerName)
                 .ConfigureAwait(false);
 
             foreach (var memory in searchResult.Results.SelectMany(c => c.Partitions))
@@ -110,7 +110,7 @@ public class ChatMemoryController : ControllerBase
         catch (Exception connectorException) when (!connectorException.IsCriticalException())
         {
             // A store exception might be thrown if the collection does not exist, depending on the memory store connector.
-            this._logger.LogError(connectorException, "Cannot search collection {0}", memoryConatinerName);
+            this._logger.LogError(connectorException, "Cannot search collection {0}", memoryContainerName);
         }
 
         return this.Ok(memories);

--- a/webapi/Models/Request/SemanticMemoryType.cs
+++ b/webapi/Models/Request/SemanticMemoryType.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace CopilotChat.WebApi.Models.Request;
+
+/// <summary>
+/// Types of semantic memories supported by chat-copilot.
+/// </summary>
+public enum SemanticMemoryType
+{
+    LongTermMemory,
+    WorkingMemory
+}

--- a/webapi/Options/PromptsOptions.cs
+++ b/webapi/Options/PromptsOptions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using CopilotChat.WebApi.Models.Request;
 
 namespace CopilotChat.WebApi.Options;
 
@@ -161,4 +163,29 @@ public class PromptsOptions
     /// </summary>
     /// <returns>A shallow copy of the options.</returns>
     internal PromptsOptions Copy() => (PromptsOptions)this.MemberwiseClone();
+
+    /// <summary>
+    /// Tries to retrieve the memoryName asociated with the specified memory type.
+    /// </summary>
+    internal bool TryGetMemoryName(string memoryType, out string memoryName)
+    {
+        memoryName = "";
+        if (!Enum.TryParse<SemanticMemoryType>(memoryType, true, out SemanticMemoryType semanitcMemoryType))
+        {
+            return false;
+        }
+
+        switch (semanitcMemoryType)
+        {
+            case SemanticMemoryType.LongTermMemory:
+                memoryName = this.LongTermMemoryName;
+                return true;
+
+            case SemanticMemoryType.WorkingMemory:
+                memoryName = this.WorkingMemoryName;
+                return true;
+
+            default: return false;
+        }
+    }
 }

--- a/webapi/Options/PromptsOptions.cs
+++ b/webapi/Options/PromptsOptions.cs
@@ -167,22 +167,22 @@ public class PromptsOptions
     /// <summary>
     /// Tries to retrieve the memoryName asociated with the specified memory type.
     /// </summary>
-    internal bool TryGetMemoryName(string memoryType, out string memoryName)
+    internal bool TryGetMemoryContainerName(string memoryType, out string memoryContainerName)
     {
-        memoryName = "";
-        if (!Enum.TryParse<SemanticMemoryType>(memoryType, true, out SemanticMemoryType semanitcMemoryType))
+        memoryContainerName = "";
+        if (!Enum.TryParse<SemanticMemoryType>(memoryType, true, out SemanticMemoryType semanticMemoryType))
         {
             return false;
         }
 
-        switch (semanitcMemoryType)
+        switch (semanticMemoryType)
         {
             case SemanticMemoryType.LongTermMemory:
-                memoryName = this.LongTermMemoryName;
+                memoryContainerName = this.LongTermMemoryName;
                 return true;
 
             case SemanticMemoryType.WorkingMemory:
-                memoryName = this.WorkingMemoryName;
+                memoryContainerName = this.WorkingMemoryName;
                 return true;
 
             default: return false;

--- a/webapi/Options/PromptsOptions.cs
+++ b/webapi/Options/PromptsOptions.cs
@@ -165,7 +165,7 @@ public class PromptsOptions
     internal PromptsOptions Copy() => (PromptsOptions)this.MemberwiseClone();
 
     /// <summary>
-    /// Tries to retrieve the memoryName asociated with the specified memory type.
+    /// Tries to retrieve the memoryContainerName associated with the specified memory type.
     /// </summary>
     internal bool TryGetMemoryContainerName(string memoryType, out string memoryContainerName)
     {

--- a/webapi/Skills/ChatSkills/SemanticChatMemoryExtractor.cs
+++ b/webapi/Skills/ChatSkills/SemanticChatMemoryExtractor.cs
@@ -42,7 +42,7 @@ internal static class SemanticChatMemoryExtractor
         {
             try
             {
-                if (!options.TryGetMemoryName(memoryType, out var memoryName))
+                if (!options.TryGetMemoryContainerName(memoryType, out var memoryName))
                 {
                     logger.LogInformation("Unable to extract semantic memory for invalid memory type {0}. Continuing...", memoryType);
                     continue;

--- a/webapi/Skills/ChatSkills/SemanticChatMemoryExtractor.cs
+++ b/webapi/Skills/ChatSkills/SemanticChatMemoryExtractor.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Extensions;
+using CopilotChat.WebApi.Models.Request;
 using CopilotChat.WebApi.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
@@ -37,11 +38,16 @@ internal static class SemanticChatMemoryExtractor
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        foreach (var memoryName in options.MemoryMap.Keys)
+        foreach (string memoryType in Enum.GetNames(typeof(SemanticMemoryType)))
         {
             try
             {
-                var semanticMemory = await ExtractCognitiveMemoryAsync(memoryName, logger);
+                if (!options.TryGetMemoryName(memoryType, out var memoryName))
+                {
+                    logger.LogInformation("Unable to extract semantic memory for invalid memory type {0}. Continuing...", memoryType);
+                    continue;
+                }
+                var semanticMemory = await ExtractCognitiveMemoryAsync(memoryType, memoryName, logger);
                 foreach (var item in semanticMemory.Items)
                 {
                     await CreateMemoryAsync(memoryName, item.ToFormattedString());
@@ -51,7 +57,7 @@ internal static class SemanticChatMemoryExtractor
             {
                 // Skip semantic memory extraction for this item if it fails.
                 // We cannot rely on the model to response with perfect Json each time.
-                logger.LogInformation("Unable to extract semantic memory for {0}: {1}. Continuing...", memoryName, ex.Message);
+                logger.LogInformation("Unable to extract semantic memory for {0}: {1}. Continuing...", memoryType, ex.Message);
                 continue;
             }
         }
@@ -59,7 +65,7 @@ internal static class SemanticChatMemoryExtractor
         /// <summary>
         /// Extracts the semantic chat memory from the chat session.
         /// </summary>
-        async Task<SemanticChatMemory> ExtractCognitiveMemoryAsync(string memoryName, ILogger logger)
+        async Task<SemanticChatMemory> ExtractCognitiveMemoryAsync(string memoryType, string memoryName, ILogger logger)
         {
             if (!options.MemoryMap.TryGetValue(memoryName, out var memoryPrompt))
             {
@@ -87,7 +93,7 @@ internal static class SemanticChatMemoryExtractor
 
             // Get token usage from ChatCompletion result and add to context
             // Since there are multiple memory types, total token usage is calculated by cumulating the token usage of each memory type.
-            TokenUtilities.GetFunctionTokenUsage(result, context, logger, $"SystemCognitive_{memoryName}");
+            TokenUtilities.GetFunctionTokenUsage(result, context, logger, $"SystemCognitive_{memoryType}");
 
             SemanticChatMemory memory = SemanticChatMemory.FromJson(result.ToString());
             return memory;

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -162,9 +162,9 @@
     "MemoryFormat": "{\"items\": [{\"label\": string, \"details\": string }]}",
     "MemoryAntiHallucination": "IMPORTANT: DO NOT INCLUDE ANY OF THE ABOVE INFORMATION IN THE GENERATED RESPONSE AND ALSO DO NOT MAKE UP OR INFER ANY ADDITIONAL INFORMATION THAT IS NOT INCLUDED BELOW. ALSO DO NOT RESPOND IF THE LAST MESSAGE WAS NOT ADDRESSED TO YOU.",
     "MemoryContinuation": "Generate a well-formed JSON of extracted context data. DO NOT include a preamble in the response. DO NOT give a list of possible responses. Only provide a single response of the json block.\nResponse:",
-    "WorkingMemoryName": "WorkingMemory",
+    "WorkingMemoryName": "WorkingMemory", // The name used for the container that stores Working Memory in the Semantic Memory database. This should not be changed once memories are established.
     "WorkingMemoryExtraction": "Extract information for a short period of time, such as a few seconds or minutes. It should be useful for performing complex cognitive tasks that require attention, concentration, or mental calculation.",
-    "LongTermMemoryName": "LongTermMemory",
+    "LongTermMemoryName": "LongTermMemory", // The name used for the container that stores Long Term Memory in the Semantic Memory database. This should not be changed once memories are established.
     "LongTermMemoryExtraction": "Extract information that is encoded and consolidated from other memory types, such as working memory or sensory memory. It should be useful for maintaining and recalling one's personal identity, history, and knowledge over time.",
     "DocumentMemoryName": "DocumentMemory",
     "MemoryIndexName": "chatmemory"


### PR DESCRIPTION
### Motivation and Context

Currently the memory retrieval API requires the name of the memory as input, however, the memoryName is something that's configured in the backend and is not known by external clients. This PR refactors things to use a memoryType based on a stable enum as the public interface to the API which allows the memoryName to remain a configuration detail of the backend.   
-->

See issue #388 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
