### PR TITLE
Fix packaging bash scripts

### DIFF
--- a/scripts/deploy/package-memorypipeline.sh
+++ b/scripts/deploy/package-memorypipeline.sh
@@ -24,41 +24,41 @@ usage() {
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
-        -c|--configuration)
+    -c | --configuration)
         CONFIGURATION="$2"
         shift
         shift
         ;;
-        -d|--dotnet)
+    -d | --dotnet)
         DOTNET="$2"
         shift
         shift
         ;;
-        -r|--runtime)
+    -r | --runtime)
         RUNTIME="$2"
         shift
         shift
         ;;
-        -o|--output)
+    -o | --output)
         OUTPUT_DIRECTORY="$2"
         shift
         shift
         ;;
-        -v|--version)
+    -v | --version)
         VERSION="$2"
         shift
         shift
         ;;
-        -i|--info)
+    -i | --info)
         INFO="$2"
         shift
         shift
         ;;
-        -nz|--no-zip)
+    -nz | --no-zip)
         NO_ZIP=true
         shift
         ;;
-        *)
+    *)
         echo "Unknown option $1"
         usage
         exit 1
@@ -86,7 +86,16 @@ if [[ ! -d "$PUBLISH_ZIP_DIRECTORY" ]]; then
 fi
 
 echo "Build configuration: $CONFIGURATION"
-dotnet publish "$SCRIPT_ROOT/../../memorypipeline/CopilotChatMemoryPipeline.csproj" --configuration $CONFIGURATION --framework $DOTNET --runtime $RUNTIME --self-contained --output "$PUBLISH_OUTPUT_DIRECTORY" /p:AssemblyVersion=$VERSION /p:FileVersion=$VERSION /p:InformationalVersion=$INFO
+dotnet publish "$SCRIPT_ROOT/../../memorypipeline/CopilotChatMemoryPipeline.csproj" \
+    --configuration $CONFIGURATION \
+    --framework $DOTNET \
+    --runtime $RUNTIME \
+    --self-contained \
+    --output "$PUBLISH_OUTPUT_DIRECTORY" \
+    //p:AssemblyVersion=$VERSION \
+    //p:FileVersion=$VERSION \
+    //p:InformationalVersion=$INFO
+
 if [ $? -ne 0 ]; then
     exit 1
 fi
@@ -98,5 +107,3 @@ if [[ -z "$NO_ZIP" ]]; then
     zip -r $PACKAGE_FILE_PATH .
     popd
 fi
-
-

--- a/scripts/deploy/package-webapi.sh
+++ b/scripts/deploy/package-webapi.sh
@@ -24,41 +24,41 @@ usage() {
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
-        -c|--configuration)
+    -c | --configuration)
         CONFIGURATION="$2"
         shift
         shift
         ;;
-        -d|--dotnet)
+    -d | --dotnet)
         DOTNET="$2"
         shift
         shift
         ;;
-        -r|--runtime)
+    -r | --runtime)
         RUNTIME="$2"
         shift
         shift
         ;;
-        -o|--output)
+    -o | --output)
         OUTPUT_DIRECTORY="$2"
         shift
         shift
         ;;
-        -v|--version)
+    -v | --version)
         VERSION="$2"
         shift
         shift
         ;;
-        -i|--info)
+    -i | --info)
         INFO="$2"
         shift
         shift
         ;;
-        -nz|--no-zip)
+    -nz | --no-zip)
         NO_ZIP=true
         shift
         ;;
-        *)
+    *)
         echo "Unknown option $1"
         usage
         exit 1
@@ -86,7 +86,16 @@ if [[ ! -d "$PUBLISH_ZIP_DIRECTORY" ]]; then
 fi
 
 echo "Build configuration: $CONFIGURATION"
-dotnet publish "$SCRIPT_ROOT/../../webapi/CopilotChatWebApi.csproj" --configuration $CONFIGURATION --framework $DOTNET --runtime $RUNTIME --self-contained --output "$PUBLISH_OUTPUT_DIRECTORY" /p:AssemblyVersion=$VERSION /p:FileVersion=$VERSION /p:InformationalVersion=$INFO
+dotnet publish "$SCRIPT_ROOT/../../webapi/CopilotChatWebApi.csproj" \
+    --configuration $CONFIGURATION \
+    --framework $DOTNET \
+    --runtime $RUNTIME \
+    --self-contained \
+    --output "$PUBLISH_OUTPUT_DIRECTORY" \
+    //p:AssemblyVersion=$VERSION \
+    //p:FileVersion=$VERSION \
+    //p:InformationalVersion=$INFO
+
 if [ $? -ne 0 ]; then
     exit 1
 fi
@@ -98,5 +107,3 @@ if [[ -z "$NO_ZIP" ]]; then
     zip -r $PACKAGE_FILE_PATH .
     popd
 fi
-
-


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Running the packaging bash scripts in the repo will result in the following error:
![image](https://github.com/microsoft/chat-copilot/assets/12570346/6cfacccb-eca0-4d54-9002-fa362e3fe12b)
This is caused by un-escaped characters in the build options.

### Description
Fix the issue by escaping the characters in the build options.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
