### PR TITLE
Sanitize log entry for memoryType

### DIFF
--- a/webapi/Controllers/ChatMemoryController.cs
+++ b/webapi/Controllers/ChatMemoryController.cs
@@ -65,12 +65,13 @@ public class ChatMemoryController : ControllerBase
         // Sanitize the log input by removing new line characters.
         // https://github.com/microsoft/chat-copilot/security/code-scanning/1
         var sanitizedChatId = GetSanitizedParameter(chatId);
+        var sanitizedMemoryType = GetSanitizedParameter(memoryType);
 
         // Map the requested memoryType to the memory store container name
         if (!this._promptOptions.TryGetMemoryContainerName(memoryType, out string memoryContainerName))
         {
-            this._logger.LogWarning("Memory type: {0} is invalid.", memoryType);
-            return this.BadRequest($"Memory type: {memoryType} is invalid.");
+            this._logger.LogWarning("Memory type: {0} is invalid.", sanitizedMemoryType);
+            return this.BadRequest($"Memory type: {sanitizedMemoryType} is invalid.");
         }
 
         // Make sure the chat session exists.


### PR DESCRIPTION
### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Address code scanning alert by sanitizing the `memoryType` parameter in `ChatMemoryController` before logging.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
