### PR TITLE
Fix null dereference from empty intent/input

### DIFF
--- a/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
+++ b/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
@@ -80,7 +80,7 @@ export const PlanViewer: React.FC<PlanViewerProps> = ({ message, messageIndex })
                 plan={plan}
                 setPlan={setPlan}
                 planState={planState}
-                description={getPlanGoal((parsedContent.userIntent ?? parsedContent.originalUserInput) ?? parsedContent.proposedPlan.description)}
+                description={getPlanGoal(parsedContent.userIntent ?? parsedContent.originalUserInput ?? parsedContent.proposedPlan.description)}
             />
             {planState === PlanState.PlanApprovalRequired && (
                 <>

--- a/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
+++ b/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
@@ -80,7 +80,7 @@ export const PlanViewer: React.FC<PlanViewerProps> = ({ message, messageIndex })
                 plan={plan}
                 setPlan={setPlan}
                 planState={planState}
-                description={getPlanGoal(parsedContent.userIntent ?? parsedContent.originalUserInput ?? parsedContent.proposedPlan.description)}
+                description={getPlanGoal((parsedContent.userIntent ?? parsedContent.originalUserInput) ?? parsedContent.proposedPlan.description)}
             />
             {planState === PlanState.PlanApprovalRequired && (
                 <>

--- a/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
+++ b/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
@@ -80,7 +80,7 @@ export const PlanViewer: React.FC<PlanViewerProps> = ({ message, messageIndex })
                 plan={plan}
                 setPlan={setPlan}
                 planState={planState}
-                description={getPlanGoal(parsedContent.userIntent ?? parsedContent.originalUserInput)}
+                description={getPlanGoal(parsedContent.userIntent ?? parsedContent.originalUserInput ?? parsedContent.proposedPlan.description)}
             />
             {planState === PlanState.PlanApprovalRequired && (
                 <>

--- a/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
+++ b/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
@@ -80,7 +80,11 @@ export const PlanViewer: React.FC<PlanViewerProps> = ({ message, messageIndex })
                 plan={plan}
                 setPlan={setPlan}
                 planState={planState}
-                description={getPlanGoal(parsedContent.userIntent ?? parsedContent.originalUserInput ?? parsedContent.proposedPlan.description)}
+                description={getPlanGoal(
+                    parsedContent.userIntent ??
+                        parsedContent.originalUserInput ??
+                        parsedContent.proposedPlan.description,
+                )}
             />
             {planState === PlanState.PlanApprovalRequired && (
                 <>

--- a/webapp/src/components/chat/tabs/PlansTab.tsx
+++ b/webapp/src/components/chat/tabs/PlansTab.tsx
@@ -144,7 +144,7 @@ function useTable(planMessages: IChatMessage[], setChatTab: () => void) {
     const items = planMessages
         .map((message, index) => {
             const parsedPlan = JSON.parse(message.content) as ProposedPlan;
-            const plangoal = (parsedPlan.userIntent ?? parsedPlan.originalUserInput) ?? parsedPlan.proposedPlan.description;
+            const plangoal = parsedPlan.userIntent ?? parsedPlan.originalUserInput ?? parsedPlan.proposedPlan.description;
 
             return {
                 index: index,

--- a/webapp/src/components/chat/tabs/PlansTab.tsx
+++ b/webapp/src/components/chat/tabs/PlansTab.tsx
@@ -144,7 +144,7 @@ function useTable(planMessages: IChatMessage[], setChatTab: () => void) {
     const items = planMessages
         .map((message, index) => {
             const parsedPlan = JSON.parse(message.content) as ProposedPlan;
-            const plangoal = parsedPlan.userIntent ?? parsedPlan.originalUserInput;
+            const plangoal = parsedPlan.userIntent ?? parsedPlan.originalUserInput ?? parsedPlan.proposedPlan.description;
 
             return {
                 index: index,

--- a/webapp/src/components/chat/tabs/PlansTab.tsx
+++ b/webapp/src/components/chat/tabs/PlansTab.tsx
@@ -144,7 +144,7 @@ function useTable(planMessages: IChatMessage[], setChatTab: () => void) {
     const items = planMessages
         .map((message, index) => {
             const parsedPlan = JSON.parse(message.content) as ProposedPlan;
-            const plangoal = parsedPlan.userIntent ?? parsedPlan.originalUserInput ?? parsedPlan.proposedPlan.description;
+            const plangoal = (parsedPlan.userIntent ?? parsedPlan.originalUserInput) ?? parsedPlan.proposedPlan.description;
 
             return {
                 index: index,

--- a/webapp/src/components/chat/tabs/PlansTab.tsx
+++ b/webapp/src/components/chat/tabs/PlansTab.tsx
@@ -144,7 +144,8 @@ function useTable(planMessages: IChatMessage[], setChatTab: () => void) {
     const items = planMessages
         .map((message, index) => {
             const parsedPlan = JSON.parse(message.content) as ProposedPlan;
-            const plangoal = parsedPlan.userIntent ?? parsedPlan.originalUserInput ?? parsedPlan.proposedPlan.description;
+            const plangoal =
+                parsedPlan.userIntent ?? parsedPlan.originalUserInput ?? parsedPlan.proposedPlan.description;
 
             return {
                 index: index,

--- a/webapp/src/libs/models/Plan.ts
+++ b/webapp/src/libs/models/Plan.ts
@@ -80,7 +80,7 @@ export interface ProposedPlan {
     state: PlanState;
 
     // User input that prompted the plan
-    originalUserInput: string;
+    originalUserInput?: string;
 
     // User intent to serves as goal of plan.
     userIntent?: string;


### PR DESCRIPTION
### Motivation and Context
Fixes #438 

### Description
Old plans do not have the `userIntent` or `originalUserInput` fields, so use the plan description as a fallback to populate the goal.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
