### PR TITLE
Adding plan error as bot response message

### DIFF
--- a/webapp/src/components/chat/plan-viewer/PlanDialogView.tsx
+++ b/webapp/src/components/chat/plan-viewer/PlanDialogView.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import {
+    Body1,
     Button,
     Dialog,
     DialogActions,
@@ -146,7 +147,11 @@ export const PlanDialogView: React.FC<IPlanDialogViewProps> = ({ goal, plan, set
             <Dialog open={openConfirmationDialog}>
                 <DialogSurface className={classes.confirmationDialog}>
                     <DialogBody>
-                        <DialogTitle>Are you sure you want to run this plan?</DialogTitle>
+                        <DialogTitle>
+                            Are you sure you want to run this plan?
+                            <br />
+                            <Body1>Please ensure all required plugins are enabled before proceeding.</Body1>
+                        </DialogTitle>
                         <DialogContent className={dialogClasses.content}>
                             <div className={classes.planView}>
                                 <PlanBody

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -154,6 +154,13 @@ export const useChat = () => {
             if (responseTokenUsage) dispatch(updateTokenUsage(JSON.parse(responseTokenUsage) as TokenUsage));
         } catch (e: any) {
             dispatch(updateBotResponseStatus({ chatId, status: undefined }));
+
+            const errorDetails = getErrorDetails(e);
+            if (errorDetails.includes('Failed to process plan')) {
+                // Error should already be reflected in bot response message. Skip alert.
+                return;
+            }
+
             const action = processPlan ? 'execute plan' : 'generate bot response';
             const errorMessage = `Unable to ${action}. Details: ${getErrorDetails(e)}`;
             dispatch(addAlert({ message: errorMessage, type: AlertType.Error }));

--- a/webapp/src/libs/models/Plan.ts
+++ b/webapp/src/libs/models/Plan.ts
@@ -11,6 +11,7 @@ export enum PlanState {
     Derived,
     PlanApprovalRequired,
     Disabled,
+    Error,
 }
 
 export enum PlanType {

--- a/webapp/src/libs/models/Plan.ts
+++ b/webapp/src/libs/models/Plan.ts
@@ -11,7 +11,6 @@ export enum PlanState {
     Derived,
     PlanApprovalRequired,
     Disabled,
-    Error,
 }
 
 export enum PlanType {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Returning all plan errors as embedded bot response message. Before, it would just be shown as a transient alert on the webapp. This allows us to maintain error context across chat sessions. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

On initial execution then re-run:
![image](https://github.com/microsoft/chat-copilot/assets/125500434/6f36a47c-8745-4310-9afb-ab19535d5eab)

And added disclaimer to confirmation dialog
![image](https://github.com/microsoft/chat-copilot/assets/125500434/93e525b3-8680-42cf-94a2-2f2a300e9515)


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
~- [ ] All unit tests pass, and I have added new tests where possible~
- [X] I didn't break anyone :smile:
