### PR TITLE
Fix artifact path in plugin deployment workflow

### DIFF
--- a/.github/workflows/copilot-deploy-plugins.yml
+++ b/.github/workflows/copilot-deploy-plugins.yml
@@ -68,4 +68,4 @@ jobs:
             --deployment-name ${{inputs.DEPLOYMENT_NAME}} \
             --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}} \
             --resource-group ${{vars.CC_DEPLOYMENT_GROUP_NAME}} \
-            --packages "${{ github.workspace }}/${{inputs.ARTIFACT_NAME}}/plugins"
+            --packages "${{ github.workspace }}/${{inputs.ARTIFACT_NAME}}"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Incorrect artifact path in the plugin deployment workflow is causing the deployment to fail.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Fix the path.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
