### PR TITLE
Fix issue with process plan api call

### DIFF
--- a/webapp/src/libs/services/ChatService.ts
+++ b/webapp/src/libs/services/ChatService.ts
@@ -171,7 +171,7 @@ export class ChatService extends BaseService {
 
         const result = await this.getResponseAsync<IAskResult>(
             {
-                commandPath: `chats/${chatId}/${processPlan ? 'processPlan' : 'messages'}`,
+                commandPath: `chats/${chatId}/${processPlan ? 'plan' : 'messages'}`,
                 method: 'POST',
                 body: ask,
             },


### PR DESCRIPTION
### Motivation and Context

In testing the chat-copilot project, I noticed that the api call to proceed with a sequential plan was failing. After poking around a bit, I found that the route was just being generated incorrectly.

### Description

Pretty straightforward, this just updates the route used to execute the plan.


### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
