### PR TITLE
Introduce Entity Framework & implement MySQL IContextStorage

### DIFF
--- a/webapi/Extensions/ServiceExtensions.cs
+++ b/webapi/Extensions/ServiceExtensions.cs
@@ -239,6 +239,35 @@ public static class CopilotChatServiceExtensions
                 break;
             }
 
+            case ChatStoreOptions.ChatStoreType.MySql:
+            {
+                if (chatStoreConfig.MySql == null)
+                {
+                    throw new InvalidOperationException("ChatStore:MySql is required when ChatStore:Type is 'MySql'");
+                }
+
+                services.AddDbContext<MySqlDbContext>(
+                    options =>
+                        options.UseMySql(
+                            chatStoreConfig.MySql.ConnectionString,
+                            ServerVersion.AutoDetect(chatStoreConfig.MySql.ConnectionString)
+                        // ,mySqlOptions => mySqlOptions.CharSetBehavior(CharSetBehavior.NeverAppend)
+                        ),
+                    ServiceLifetime.Transient
+                );
+
+                chatSessionStorageContext = new MySqlStorageContext<ChatSession>(services.BuildServiceProvider().GetRequiredService<MySqlDbContext>());
+                chatMessageStorageContext = new MySqlStorageContext<ChatMessage>(services.BuildServiceProvider().GetRequiredService<MySqlDbContext>());
+                chatMemorySourceStorageContext = new MySqlStorageContext<MemorySource>(services.BuildServiceProvider().GetRequiredService<MySqlDbContext>());
+                chatParticipantStorageContext = new MySqlStorageContext<ChatParticipant>(services.BuildServiceProvider().GetRequiredService<MySqlDbContext>());
+
+                services.AddScoped<IStorageContext<ChatSession>, MySqlStorageContext<ChatSession>>();
+                services.AddScoped<IStorageContext<ChatMessage>, MySqlStorageContext<ChatMessage>>();
+                services.AddScoped<IStorageContext<MemorySource>, MySqlStorageContext<MemorySource>>();
+                services.AddScoped<IStorageContext<ChatParticipant>, MySqlStorageContext<ChatParticipant>>();
+                break;
+            }
+
             default:
             {
                 throw new InvalidOperationException(

--- a/webapi/Options/ChatStoreOptions.cs
+++ b/webapi/Options/ChatStoreOptions.cs
@@ -27,7 +27,12 @@ public class ChatStoreOptions
         /// <summary>
         /// Azure CosmosDB based persistent chat store.
         /// </summary>
-        Cosmos
+        Cosmos,
+
+        /// <summary>
+        /// MySql based persistent chat store.
+        /// </summary>
+        MySql
     }
 
     /// <summary>
@@ -46,4 +51,10 @@ public class ChatStoreOptions
     /// </summary>
     [RequiredOnPropertyValue(nameof(Type), ChatStoreType.Cosmos)]
     public CosmosOptions? Cosmos { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration for the MySql chat store.
+    /// </summary>
+    [RequiredOnPropertyValue(nameof(Type), ChatStoreType.MySql)]
+    public MySqlOptions? MySql { get; set; }
 }

--- a/webapi/Options/MySqlOptions.cs
+++ b/webapi/Options/MySqlOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace CopilotChat.WebApi.Options;
+
+public class MySqlOptions
+{
+    [Required, NotEmptyOrWhitespace]
+    public string Database { get; set; } = string.Empty;
+
+    [Required, NotEmptyOrWhitespace]
+    public string ConnectionString { get; set; } = string.Empty;
+}

--- a/webapi/Storage/MySqlDbContext.cs
+++ b/webapi/Storage/MySqlDbContext.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using CopilotChat.WebApi.Models.Storage;
+using Newtonsoft.Json;
+
+namespace CopilotChat.WebApi.Storage;
+
+public class MySqlDbContext : DbContext
+{
+    public MySqlDbContext(DbContextOptions<MySqlDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<ChatSession> ChatSession { get; set; }
+    public DbSet<ChatMessage> ChatMessage { get; set; }
+    public DbSet<MemorySource> MemorySource { get; set; }
+    public DbSet<ChatParticipant> ChatParticipant { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ChatMessage>()
+            .Property(c => c.TokenUsage)
+            .HasConversion(
+                v => JsonConvert.SerializeObject(v),
+                v => JsonConvert.DeserializeObject<Dictionary<string, int>>(v))
+            .HasMaxLength(5000);
+    }
+}

--- a/webapi/Storage/MySqlStorageContext.cs
+++ b/webapi/Storage/MySqlStorageContext.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace CopilotChat.WebApi.Storage
+{
+    public class MySqlStorageContext<T> : IStorageContext<T>, IDisposable where T : class, IStorageEntity
+    {
+        private readonly MySqlDbContext _context;
+        private readonly DbSet<T> _dbSet;
+
+        public MySqlStorageContext(MySqlDbContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _dbSet = _context.Set<T>();
+        }
+
+        private void ValidateEntityId(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentOutOfRangeException(nameof(id), "Entity Id cannot be null or empty.");
+            }
+        }
+
+        public async Task<IEnumerable<T>> QueryEntitiesAsync(Func<T, bool> predicate)
+        {
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return await Task.Run(() => _dbSet.Where(predicate).ToList()).ConfigureAwait(false);
+        }
+
+        public async Task CreateAsync(T entity)
+        {
+            if (entity == null)
+            {
+                throw new ArgumentNullException(nameof(entity));
+            }
+
+            ValidateEntityId(entity.Id);
+
+            _dbSet.Add(entity);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        public async Task DeleteAsync(T entity)
+        {
+            if (entity == null)
+            {
+                throw new ArgumentNullException(nameof(entity));
+            }
+
+            ValidateEntityId(entity.Id);
+
+            _dbSet.Remove(entity);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        public async Task<T> ReadAsync(string entityId, string partitionKey)
+        {
+            ValidateEntityId(entityId);
+
+            var entity = await _dbSet.FindAsync(entityId).ConfigureAwait(false);
+            if (entity == null)
+            {
+                throw new KeyNotFoundException($"Entity with id {entityId} not found.");
+            }
+
+            return entity;
+        }
+
+        public async Task UpsertAsync(T entity)
+        {
+            if (entity == null)
+            {
+                throw new ArgumentNullException(nameof(entity));
+            }
+
+            ValidateEntityId(entity.Id);
+
+            var existingEntity = await _dbSet.FindAsync(entity.Id).ConfigureAwait(false);
+            if (existingEntity != null)
+            {
+                _context.Entry(entity).State = EntityState.Modified;
+            }
+            else
+            {
+                _dbSet.Add(entity);
+            }
+
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        public void Dispose() => _context.Dispose();
+    }
+}

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -119,6 +119,10 @@
       "ChatMemorySourcesContainer": "chatmemorysources",
       "ChatParticipantsContainer": "chatparticipants"
       // "ConnectionString": // dotnet user-secrets set "ChatStore:Cosmos:ConnectionString" "MY_COSMOS_CONNECTION_STRING"
+    },
+    "MySql": {
+      "Database": "",
+      "ConnectionString": ""
     }
   },
   //


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Original issue: #478 

Some background:
I want/need to persist the chat in something other than Cosmos or the filesystem. I'm aware that C# has a long history of ORM usage, so I thought it would make sense to implement MySQL for this, and introduce EF to make sure the datamodel layer is easy to change.

@Rainson12 has also made an effort in the same vein, for MariaDB, as seen here #242

So now I know of 3 people that want this, and I haven't found anyone so far that's opposed to the idea of EF.


### Description

This has serious consequences, during local testing I ran into a lot of problems surrounding concurrency. That meant that I had to change classes that aren't directly related to the change I'm trying to make. 

Also, right now there seems to be some kind of hack surrounding the scope for the Cosmos implementation that I'd like to get rid of as well.

I'd like some help with this! So if you want to help out, let me know. I don't really know all that much about EF itself, and I want to make sure we get this right the first time.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
