### PR TITLE
WIP: Remove Volatile and Postgres from deployment templates

### DIFF
--- a/scripts/deploy/deploy-azure.ps1
+++ b/scripts/deploy/deploy-azure.ps1
@@ -58,14 +58,10 @@ param(
     # Azure AD cloud instance for authenticating users
     $AzureAdInstance = "https://login.microsoftonline.com",
 
-    [ValidateSet("Volatile", "AzureCognitiveSearch", "Qdrant", "Postgres")]
+    [ValidateSet("AzureCognitiveSearch", "Qdrant")]
     [string]
     # What method to use to persist embeddings
     $MemoryStore = "AzureCognitiveSearch",
-
-    [SecureString]
-    # Password for the Postgres database
-    $SqlAdminPassword,
 
     [switch]
     # Don't deploy Cosmos DB for chat storage - Use volatile memory instead
@@ -109,11 +105,6 @@ if ($AIService -eq "OpenAI" -and !$AIApiKey) {
     exit 1
 }
 
-if ($MemoryStore -eq "Postgres" -and !$SqlAdminPassword) {
-    Write-Host "When MemoryStore is Postgres, SqlAdminPassword must be set"
-    exit 1
-}
-
 $jsonConfig = "
 {
     `\`"webAppServiceSku`\`": { `\`"value`\`": `\`"$WebAppServiceSku`\`" },
@@ -130,8 +121,7 @@ $jsonConfig = "
     `\`"deployNewAzureOpenAI`\`": { `\`"value`\`": $(If ($DeployAzureOpenAI) {"true"} Else {"false"}) },
     `\`"memoryStore`\`": { `\`"value`\`": `\`"$MemoryStore`\`" },
     `\`"deployCosmosDB`\`": { `\`"value`\`": $(If (!($NoCosmosDb)) {"true"} Else {"false"}) },
-    `\`"deploySpeechServices`\`": { `\`"value`\`": $(If (!($NoSpeechServices)) {"true"} Else {"false"}) },
-    `\`"sqlAdminPassword`\`": { `\`"value`\`": `\`"$(If ($SqlAdminPassword) {ConvertFrom-SecureString $SqlAdminPassword -AsPlainText} Else {$null})`\`" }
+    `\`"deploySpeechServices`\`": { `\`"value`\`": $(If (!($NoSpeechServices)) {"true"} Else {"false"}) }
 }
 "
 

--- a/scripts/deploy/deploy-azure.sh
+++ b/scripts/deploy/deploy-azure.sh
@@ -22,8 +22,7 @@ usage() {
     echo "  -i, --instance AZURE_AD_INSTANCE           Azure AD cloud instance for authenticating users"
     echo "                                             (default: \"https://login.microsoftonline.com\")"
     echo "  -ms, --memory-store                        Method to use to persist embeddings. Valid values are"
-    echo "                                             \"AzureCognitiveSearch\" (default), \"Qdrant\", \"Postgres\" and \"Volatile\""
-    echo "  -sap, --sql-admin-password                 Password for the PostgreSQL Server admin user"
+    echo "                                             \"AzureCognitiveSearch\" (default) and \"Qdrant\""
     echo "  -nc, --no-cosmos-db                        Don't deploy Cosmos DB for chat storage - Use volatile memory instead"
     echo "  -ns, --no-speech-services                  Don't deploy Speech Services to enable speech as chat input"
     echo "  -dd, --debug-deployment                    Switches on verbose template deployment output"
@@ -98,11 +97,6 @@ while [[ $# -gt 0 ]]; do
         MEMORY_STORE=="$2"
         shift
         ;;
-    -sap | --sql-admin-password)
-        SQL_ADMIN_PASSWORD="$2"
-        shift
-        shift
-        ;;
     -nc | --no-cosmos-db)
         NO_COSMOS_DB=true
         shift
@@ -166,13 +160,6 @@ if [[ "${AI_SERVICE_TYPE,,}" = "openai" ]] && [[ -z "$AI_SERVICE_KEY" ]]; then
     exit 1
 fi
 
-# If MEMORY_STORE is Postges, then SQL_ADMIN_PASSWORD is mandatory
-if [[ "${MEMORY_STORE,,}" = "postgres" ]] && [[ -z "$SQL_ADMIN_PASSWORD" ]]; then
-    echo "When --memory-store is 'Postgres', --sql-admin-password must be set."
-    usage
-    exit 1
-fi
-
 # If resource group is not set, then set it to rg-DEPLOYMENT_NAME
 if [ -z "$RESOURCE_GROUP" ]; then
     RESOURCE_GROUP="rg-${DEPLOYMENT_NAME}"
@@ -213,7 +200,6 @@ JSON_CONFIG=$(
     "frontendClientId": { "value": "$FRONTEND_CLIENT_ID" },
     "deployNewAzureOpenAI": { "value": $([ "$NO_NEW_AZURE_OPENAI" = true ] && echo "false" || echo "true") },
     "memoryStore": { "value": "$MEMORY_STORE" },
-    "sqlAdminPassword": { "value": "$SQL_ADMIN_PASSWORD" },
     "deployCosmosDB": { "value": $([ "$NO_COSMOS_DB" = true ] && echo "false" || echo "true") },
     "deploySpeechServices": { "value": $([ "$NO_SPEECH_SERVICES" = true ] && echo "false" || echo "true") }
 }

--- a/scripts/deploy/main.json
+++ b/scripts/deploy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "4239752954578942550"
+      "version": "0.22.6.54827",
+      "templateHash": "12087965196433690534"
     }
   },
   "parameters": {
@@ -144,12 +144,10 @@
     },
     "memoryStore": {
       "type": "string",
-      "defaultValue": "Volatile",
+      "defaultValue": "AzureCognitiveSearch",
       "allowedValues": [
-        "Volatile",
         "AzureCognitiveSearch",
-        "Qdrant",
-        "Postgres"
+        "Qdrant"
       ],
       "metadata": {
         "description": "What method to use to persist embeddings"
@@ -188,13 +186,6 @@
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Region for the resources"
-      }
-    },
-    "sqlAdminPassword": {
-      "type": "securestring",
-      "defaultValue": "[newGuid()]",
-      "metadata": {
-        "description": "PostgreSQL admin password"
       }
     }
   },
@@ -378,30 +369,6 @@
             "value": "[if(parameters('deployCosmosDB'), listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', toLower(format('cosmos-{0}', variables('uniqueName')))), '2023-04-15').connectionStrings[0].connectionString, '')]"
           },
           {
-            "name": "MemoryStore:Type",
-            "value": "[parameters('memoryStore')]"
-          },
-          {
-            "name": "MemoryStore:Qdrant:Host",
-            "value": "[if(equals(parameters('memoryStore'), 'Qdrant'), format('https://{0}', reference(resourceId('Microsoft.Web/sites', format('app-{0}-qdrant', variables('uniqueName'))), '2022-09-01').defaultHostName), '')]"
-          },
-          {
-            "name": "MemoryStore:Qdrant:Port",
-            "value": "443"
-          },
-          {
-            "name": "MemoryStore:AzureCognitiveSearch:Endpoint",
-            "value": "[if(equals(parameters('memoryStore'), 'AzureCognitiveSearch'), format('https://{0}.search.windows.net', format('acs-{0}', variables('uniqueName'))), '')]"
-          },
-          {
-            "name": "MemoryStore:AzureCognitiveSearch:Key",
-            "value": "[if(equals(parameters('memoryStore'), 'AzureCognitiveSearch'), listAdminKeys(resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName'))), '2022-09-01').primaryKey, '')]"
-          },
-          {
-            "name": "MemoryStore:Postgres:ConnectionString",
-            "value": "[if(equals(parameters('memoryStore'), 'Postgres'), format('Host={0}:5432;Username=citus;Password={1};Database=citus', reference(resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName'))), '2022-11-08').serverNames[0].fullyQualifiedDomainName, parameters('sqlAdminPassword')), '')]"
-          },
-          {
             "name": "AzureSpeech:Region",
             "value": "[parameters('location')]"
           },
@@ -518,6 +485,10 @@
             "value": "[if(equals(parameters('memoryStore'), 'AzureCognitiveSearch'), listAdminKeys(resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName'))), '2022-09-01').primaryKey, '')]"
           },
           {
+            "name": "SemanticMemory:Services:Qdrant:Endpoint",
+            "value": "[if(equals(parameters('memoryStore'), 'Qdrant'), format('https://{0}', reference(resourceId('Microsoft.Web/sites', format('app-{0}-qdrant', variables('uniqueName'))), '2022-09-01').defaultHostName), '')]"
+          },
+          {
             "name": "SemanticMemory:Services:AzureOpenAIText:Auth",
             "value": "ApiKey"
           },
@@ -579,7 +550,6 @@
         "[resourceId('Microsoft.DocumentDB/databaseAccounts', toLower(format('cosmos-{0}', variables('uniqueName'))))]",
         "[resourceId('Microsoft.Web/sites', format('function-{0}-websearcher-plugin', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName')))]",
-        "[resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('cog-speech-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.Storage/storageAccounts', format('st{0}', variables('rgIdHash')))]"
       ]
@@ -697,6 +667,10 @@
             "value": "[if(equals(parameters('memoryStore'), 'AzureCognitiveSearch'), listAdminKeys(resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName'))), '2022-09-01').primaryKey, '')]"
           },
           {
+            "name": "SemanticMemory:Services:Qdrant:Endpoint",
+            "value": "[if(equals(parameters('memoryStore'), 'Qdrant'), format('https://{0}', reference(resourceId('Microsoft.Web/sites', format('app-{0}-qdrant', variables('uniqueName'))), '2022-09-01').defaultHostName), '')]"
+          },
+          {
             "name": "SemanticMemory:Services:AzureOpenAIText:Auth",
             "value": "ApiKey"
           },
@@ -761,6 +735,7 @@
       "dependsOn": [
         "[resourceId('Microsoft.Insights/components', format('appins-{0}-memorypipeline', variables('uniqueName')))]",
         "[resourceId('Microsoft.Web/sites', format('app-{0}-memorypipeline', variables('uniqueName')))]",
+        "[resourceId('Microsoft.Web/sites', format('app-{0}-qdrant', variables('uniqueName')))]",
         "[resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('cog-ocr-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName')))]",
@@ -1097,16 +1072,6 @@
               "privateEndpointNetworkPolicies": "Disabled",
               "privateLinkServiceNetworkPolicies": "Enabled"
             }
-          },
-          {
-            "name": "postgresSubnet",
-            "properties": {
-              "addressPrefix": "10.0.3.0/24",
-              "serviceEndpoints": [],
-              "delegations": [],
-              "privateEndpointNetworkPolicies": "Disabled",
-              "privateLinkServiceNetworkPolicies": "Enabled"
-            }
           }
         ]
       },
@@ -1139,6 +1104,7 @@
       }
     },
     {
+      "condition": "[equals(parameters('memoryStore'), 'Qdrant')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2022-11-01",
       "name": "[format('nsg-{0}-qdrant', variables('uniqueName'))]",
@@ -1347,96 +1313,6 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', toLower(format('cosmos-{0}', variables('uniqueName'))), 'CopilotChat')]"
-      ]
-    },
-    {
-      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
-      "type": "Microsoft.DBforPostgreSQL/serverGroupsv2",
-      "apiVersion": "2022-11-08",
-      "name": "[format('pg-{0}', variables('uniqueName'))]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "postgresqlVersion": "15",
-        "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
-        "enableHa": false,
-        "coordinatorVCores": 1,
-        "coordinatorServerEdition": "BurstableMemoryOptimized",
-        "coordinatorStorageQuotaInMb": 32768,
-        "nodeVCores": 4,
-        "nodeCount": 0,
-        "nodeStorageQuotaInMb": 524288,
-        "nodeEnablePublicIpAccess": false
-      }
-    },
-    {
-      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
-      "type": "Microsoft.Network/privateDnsZones",
-      "apiVersion": "2020-06-01",
-      "name": "privatelink.postgres.cosmos.azure.com",
-      "location": "global"
-    },
-    {
-      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
-      "type": "Microsoft.Network/privateEndpoints",
-      "apiVersion": "2023-05-01",
-      "name": "[format('pg-{0}-pe', variables('uniqueName'))]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "subnet": {
-          "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[2].id]"
-        },
-        "privateLinkServiceConnections": [
-          {
-            "name": "postgres",
-            "properties": {
-              "privateLinkServiceId": "[resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName')))]",
-              "groupIds": [
-                "coordinator"
-              ]
-            }
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.DBforPostgreSQL/serverGroupsv2', format('pg-{0}', variables('uniqueName')))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName')))]"
-      ]
-    },
-    {
-      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
-      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', 'privatelink.postgres.cosmos.azure.com', format('pg-{0}-vnl', variables('uniqueName')))]",
-      "location": "global",
-      "properties": {
-        "virtualNetwork": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName')))]"
-        },
-        "registrationEnabled": true
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.cosmos.azure.com')]",
-        "[resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName')))]"
-      ]
-    },
-    {
-      "condition": "[equals(parameters('memoryStore'), 'Postgres')]",
-      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-      "apiVersion": "2023-04-01",
-      "name": "[format('{0}/default', format('pg-{0}-pe', variables('uniqueName')))]",
-      "properties": {
-        "privateDnsZoneConfigs": [
-          {
-            "name": "postgres",
-            "properties": {
-              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.cosmos.azure.com')]"
-            }
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.cosmos.azure.com')]",
-        "[resourceId('Microsoft.Network/privateEndpoints', format('pg-{0}-pe', variables('uniqueName')))]"
       ]
     },
     {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Volatile and Postgres were no longer supported since the integration of Semantic Memory. However, they are not removed from the deployment templates.

Address issues: https://github.com/microsoft/chat-copilot/issues/510


### Description
Remove Volatile and Postgres as memory store options from the deployment templates.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
