### PR TITLE
Make deploy-webapi do all it needs to by default

### DIFF
--- a/.github/workflows/copilot-build-backend.yml
+++ b/.github/workflows/copilot-build-backend.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Package Copilot Chat WebAPI
         run: |
-          scripts\deploy\package-webapi.ps1 -Configuration Release -DotnetFramework net6.0 -TargetRuntime win-x64 -OutputDirectory ${{ github.workspace }}\scripts\deploy -Version ${{ steps.versiontag.outputs.versiontag }} -InformationalVersion "Built from commit ${{ steps.gitversion.outputs.ShortSha }} on $(Get-Date -Format "yyyy-MM-dd")" -SkipFrontendFiles=${{ github.event_name == 'pull_request' }}
+          scripts\deploy\package-webapi.ps1 -Configuration Release -DotnetFramework net6.0 -TargetRuntime win-x64 -OutputDirectory ${{ github.workspace }}\scripts\deploy -Version ${{ steps.versiontag.outputs.versiontag }} -InformationalVersion "Built from commit ${{ steps.gitversion.outputs.ShortSha }} on $(Get-Date -Format 'yyyy-MM-dd')" -SkipFrontendFiles=${{ github.event_name == 'pull_request' }}
 
       - name: Upload package to artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/copilot-deploy-backend.yml
+++ b/.github/workflows/copilot-deploy-backend.yml
@@ -81,4 +81,4 @@ jobs:
 
       - name: "Deploy"
         run: |
-          scripts/deploy/deploy-webapi.sh -p "${{ github.workspace }}/${{inputs.ARTIFACT_NAME}}/webapi.zip" -d ${{inputs.DEPLOYMENT_NAME}} -s ${{secrets.AZURE_SUBSCRIPTION_ID}} -rg ${{vars.CC_DEPLOYMENT_GROUP_NAME}} --register-cors
+          scripts/deploy/deploy-webapi.sh -p "${{ github.workspace }}/${{inputs.ARTIFACT_NAME}}/webapi.zip" -d ${{inputs.DEPLOYMENT_NAME}} -s ${{secrets.AZURE_SUBSCRIPTION_ID}} -rg ${{vars.CC_DEPLOYMENT_GROUP_NAME}} --skip-app-registration

--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,7 @@ FodyWeavers.xsd
 *.pem
 
 .env
+.env.production
 certs/
 launchSettings.json
 config.development.yaml

--- a/scripts/deploy/deploy-webapi.ps1
+++ b/scripts/deploy/deploy-webapi.ps1
@@ -27,7 +27,7 @@ param(
     $PackageFilePath = "$PSScriptRoot/out/webapi.zip",
 
     [switch]
-    # Don't attempt to add our URIs in app registration's redirect URIs
+    # Don't attempt to add our URIs in frontend app registration's redirect URIs
     $SkipAppRegistration,
     
     [switch]

--- a/scripts/deploy/deploy-webapi.ps1
+++ b/scripts/deploy/deploy-webapi.ps1
@@ -27,12 +27,12 @@ param(
     $PackageFilePath = "$PSScriptRoot/out/webapi.zip",
 
     [switch]
-    # Switch to add our URIs in app registration's redirect URIs if missing
-    $EnsureUriInAppRegistration,
+    # Don't attempt to add our URIs in app registration's redirect URIs
+    $SkipAppRegistration,
     
     [switch]
-    # Switch to add our URIs in CORS origins for our plugins
-    $RegisterPluginCors
+    # Don't attempt to add our URIs in CORS origins for our plugins
+    $SkipCorsRegistration
 )
 
 # Ensure $PackageFilePath exists
@@ -107,7 +107,7 @@ if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-if ($EnsureUriInAppRegistration) {
+if (-Not $SkipAppRegistration) {
     $webapiSettings = $(az webapp config appsettings list --name $webapiName --resource-group $ResourceGroupName | ConvertFrom-JSON)
     $frontendClientId = ($webapiSettings | Where-Object -Property name -EQ -Value Frontend:AadClientId).value
     $objectId = (az ad app show --id $frontendClientId | ConvertFrom-Json).id
@@ -137,12 +137,13 @@ if ($EnsureUriInAppRegistration) {
             --headers 'Content-Type=application/json' `
             --body $body
         if ($LASTEXITCODE -ne 0) {
+            Write-Host "Failed to update AAD app registration - Use -SkipAppRegistration switch to skip this step"
             exit $LASTEXITCODE
         }
     }
 }
 
-if ($RegisterPluginCors) {
+if (-Not $SkipCorsRegistration) {
     foreach ($pluginName in $pluginNames) {
         $allowedOrigins = $((az webapp cors show --name $pluginName --resource-group $ResourceGroupName --subscription $Subscription | ConvertFrom-Json).allowedOrigins)
         foreach ($address in $origins) {
@@ -150,6 +151,10 @@ if ($RegisterPluginCors) {
             Write-Host "Ensuring '$origin' is included in CORS origins for plugin '$pluginName'..."
             if (-not $allowedOrigins -contains $origin) {
                 az webapp cors add --name $pluginName --resource-group $ResourceGroupName --subscription $Subscription --allowed-origins $origin
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "Failed to update plugin CORS URIs - Use -SkipCorsRegistration switch to skip this step"
+                    exit $LASTEXITCODE
+                }
             }
         }
     }

--- a/scripts/deploy/deploy-webapi.sh
+++ b/scripts/deploy/deploy-webapi.sh
@@ -12,7 +12,7 @@ usage() {
     echo "  -p, --package PACKAGE_FILE_PATH         Path to the package file from a 'package-webapi.sh' run (default: \"./out/webapi.zip\")"
     echo "  -o, --slot DEPLOYMENT_SLOT              Name of the target web app deployment slot"
     echo "  -sr, --skip-app-registration            Skip adding our URI in app registration's redirect URIs"
-    echo "  -sc, --skip-cors-registraion            Skip registration of service with the plugins as allowed CORS origin"
+    echo "  -sc, --skip-cors-registration           Skip registration of service with the plugins as allowed CORS origin"
 }
 
 # Parse arguments
@@ -48,7 +48,7 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
-    -c|--skip-cors-registraion)
+    -c|--skip-cors-registration)
         REGISTER_CORS=false
         shift
         ;;

--- a/scripts/deploy/deploy-webapi.sh
+++ b/scripts/deploy/deploy-webapi.sh
@@ -11,8 +11,8 @@ usage() {
     echo "  -rg, --resource-group RESOURCE_GROUP    Resource group name from a 'deploy-azure.sh' deployment (mandatory)"
     echo "  -p, --package PACKAGE_FILE_PATH         Path to the package file from a 'package-webapi.sh' run (default: \"./out/webapi.zip\")"
     echo "  -o, --slot DEPLOYMENT_SLOT              Name of the target web app deployment slot"
-    echo "  -r, --register-app                      Switch to add our URI in app registration's redirect URIs if missing"
-    echo "  -c, --register-cors                     Register service with the plugins as allowed CORS origin"
+    echo "  -sr, --skip-app-registration            Skip adding our URI in app registration's redirect URIs"
+    echo "  -sc, --skip-cors-registraion            Skip registration of service with the plugins as allowed CORS origin"
 }
 
 # Parse arguments
@@ -39,8 +39,8 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
-    -r|--register-app)
-        REGISTER_APP=true
+    -r|--skip-app-registration)
+        REGISTER_APP=false
         shift
         ;;
     -o|--slot)
@@ -48,8 +48,8 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
-    -c|--register-cors)
-        REGISTER_CORS=true
+    -c|--skip-cors-registraion)
+        REGISTER_CORS=false
         shift
         ;;
     *)
@@ -143,7 +143,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [[ -n $REGISTER_APP ]]; then
+if [[ -z $REGISTER_APP ]]; then
     WEBAPI_SETTINGS=$(az webapp config appsettings list --name $WEB_API_NAME --resource-group $RESOURCE_GROUP --output json)
     FRONTEND_CLIENT_ID=$(echo $WEBAPI_SETTINGS | jq -r '.[] | select(.name == "Frontend:AadClientId") | .value')
     OBJECT_ID=$(az ad app show --id $FRONTEND_CLIENT_ID | jq -r '.id')
@@ -177,13 +177,13 @@ if [[ -n $REGISTER_APP ]]; then
             --body $BODY
 
         if [ $? -ne 0 ]; then
-            echo "Failed to update app registration $OBJECT_ID with redirect URIs"
+            echo "Failed to update app registration $OBJECT_ID with redirect URIs - Use -sc switch to skip this step"
             exit 1
         fi
     fi
 fi
 
-if [[ -n $REGISTER_CORS ]]; then
+if [[ -z $REGISTER_CORS ]]; then
     for PLUGIN_NAME in $PLUGIN_NAMES; do
         ALLOWED_ORIGINS=$(az webapp cors show --name $PLUGIN_NAME --resource-group $RESOURCE_GROUP --subscription $SUBSCRIPTION | jq -r '.allowedOrigins[]')
         for ADDRESS in $(echo "$ORIGINS"); do
@@ -192,7 +192,7 @@ if [[ -n $REGISTER_CORS ]]; then
             if [[ ! "$ALLOWED_ORIGINS" =~ "$ORIGIN" ]]; then
                 az webapp cors add --name $PLUGIN_NAME --resource-group $RESOURCE_GROUP --subscription $SUBSCRIPTION --allowed-origins "$ORIGIN"
                 if [ $? -ne 0 ]; then
-                    echo "Failed to update CORS origins with $ORIGIN"
+                    echo "Failed to update CORS origins with $ORIGIN - Use -sc switch to skip this step"
                     exit 1
                 fi
             fi 

--- a/scripts/deploy/package-webapi.ps1
+++ b/scripts/deploy/package-webapi.ps1
@@ -60,6 +60,14 @@ if (-Not $SkipFrontendFiles) {
     Write-Host "Building static frontend files..."
 
     Push-Location -Path "$PSScriptRoot/../../webapp"
+    
+    if ($Version -ne "0.0.0") {
+        Add-Content -Path ./.env -Value "REACT_APP_SK_VERSION=$Version"
+    }
+    
+    if ($InformationalVersion -ne "") {
+        Add-Content -Path ./.env -Value "REACT_APP_SK_BUILD_INFO=$InformationalVersion"
+    }
 
     Write-Host "Installing yarn dependencies..."
     yarn install

--- a/scripts/deploy/package-webapi.sh
+++ b/scripts/deploy/package-webapi.sh
@@ -112,13 +112,14 @@ if [[ -z "$SKIP_FRONTEND" ]]; then
 
     pushd "$SCRIPT_ROOT/../../webapp"
 
-    if [ "$Version" != "0.0.0" ]; then
-        echo "REACT_APP_SK_VERSION=$Version" >> .env
+    filePath="./.env.production"
+    if [ -f "$filePath" ]; then
+        rm "$filePath"
     fi
 
-    if [ -n "$InformationalVersion" ]; then
-        echo "REACT_APP_SK_BUILD_INFO=$InformationalVersion" >> .env
-    fi
+    echo "REACT_APP_BACKEND_URI=" >> "$filePath"
+    echo "REACT_APP_SK_VERSION=$Version" >> "$filePath"
+    echo "REACT_APP_SK_BUILD_INFO=$InformationalVersion" >> "$filePath"
 
     echo "Installing yarn dependencies..."
     yarn install

--- a/scripts/deploy/package-webapi.sh
+++ b/scripts/deploy/package-webapi.sh
@@ -112,6 +112,14 @@ if [[ -z "$SKIP_FRONTEND" ]]; then
 
     pushd "$SCRIPT_ROOT/../../webapp"
 
+    if [ "$Version" != "0.0.0" ]; then
+        echo "REACT_APP_SK_VERSION=$Version" >> .env
+    fi
+
+    if [ -n "$InformationalVersion" ]; then
+        echo "REACT_APP_SK_BUILD_INFO=$InformationalVersion" >> .env
+    fi
+
     echo "Installing yarn dependencies..."
     yarn install
     if [ $? -ne 0 ]; then

--- a/webapp/src/libs/services/BaseService.ts
+++ b/webapp/src/libs/services/BaseService.ts
@@ -12,7 +12,9 @@ interface ServiceRequest {
 
 const noResponseBodyStatusCodes = [202, 204];
 
-export const BackendServiceUrl = process.env.REACT_APP_BACKEND_URI ?? window.origin;
+export const BackendServiceUrl = (process.env.REACT_APP_BACKEND_URI == null ||
+                                  process.env.REACT_APP_BACKEND_URI.trim() === "") ? window.origin
+                                  : process.env.REACT_APP_BACKEND_URI;
 export const NetworkErrorMessage = '\n\nPlease check that your backend is running and that it is accessible by the app';
 
 export class BaseService {

--- a/webapp/src/libs/services/BaseService.ts
+++ b/webapp/src/libs/services/BaseService.ts
@@ -12,9 +12,10 @@ interface ServiceRequest {
 
 const noResponseBodyStatusCodes = [202, 204];
 
-export const BackendServiceUrl = (process.env.REACT_APP_BACKEND_URI == null ||
-                                  process.env.REACT_APP_BACKEND_URI.trim() === "") ? window.origin
-                                  : process.env.REACT_APP_BACKEND_URI;
+export const BackendServiceUrl =
+    process.env.REACT_APP_BACKEND_URI == null || process.env.REACT_APP_BACKEND_URI.trim() === ''
+        ? window.origin
+        : process.env.REACT_APP_BACKEND_URI;
 export const NetworkErrorMessage = '\n\nPlease check that your backend is running and that it is accessible by the app';
 
 export class BaseService {


### PR DESCRIPTION
### Motivation and Context
Some switches need to be included at the command line to ensure proper modification of the AAD app registration and addition of our URIs to the plugin CORS. These steps should be done by default.

### Description
Make all required steps run by default.
Fixed population of frontend version info

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
