### PR TITLE
Add blobs settings in webapi docker .env.example

### DIFF
--- a/docker/webapi/.env.example
+++ b/docker/webapi/.env.example
@@ -18,3 +18,6 @@ SemanticMemory__Services__AzureOpenAIText__Deployment=
 SemanticMemory__Services__AzureOpenAIText__Endpoint=
 SemanticMemory__Services__AzureOpenAIText__APIKey=
 
+# Azure blobs settings
+SemanticMemory__Services__AzureBlobs__Auth=
+SemanticMemory__Services__AzureBlobs__ConnectionString=


### PR DESCRIPTION
### Motivation and Context

docker/webapi/.env.example should have below settings as the template to create .env file, otherwise, webapi container will failed to start
```
# Azure blobs settings
SemanticMemory__Services__AzureBlobs__Auth=
SemanticMemory__Services__AzureBlobs__ConnectionString=
```

### Description

docker/webapi/.env.example should have below settings as the template to create .env file, otherwise, webapi container will failed to start
```
# Azure blobs settings
SemanticMemory__Services__AzureBlobs__Auth=
SemanticMemory__Services__AzureBlobs__ConnectionString=
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
