### PR TITLE
Update SemanticChatMemoryItem.cs

### DIFF
--- a/webapi/Skills/ChatSkills/SemanticChatMemoryItem.cs
+++ b/webapi/Skills/ChatSkills/SemanticChatMemoryItem.cs
@@ -38,6 +38,6 @@ public class SemanticChatMemoryItem
     /// <returns>A formatted string representing the item.</returns>
     public string ToFormattedString()
     {
-        return $"{this.Label}: {this.Details.Trim()}";
+        return $"{this.Label}: {this.Details?.Trim()}";
     }
 }


### PR DESCRIPTION
### Motivation and Context

  1. Why is this change required?  Possible Null reference exception.
  2. What problem does it solve? Fix null reference in ToFormattedString function
  3. What scenario does it contribute to?  If ( Item ) object label and Details are null.

### Description

In the `SemanticChatMemoryItem.ToFormattedString` function, ensure that the `Details` property is not null before trimming it. This change prevents potential NullReferenceExceptions when the `Details` property is null.

This modification ensures the stability of the `ToFormattedString` function when used in other parts of the code.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
