### PR TITLE
Workflow fixes

### DIFF
--- a/.github/workflows/copilot-deploy-backend.yml
+++ b/.github/workflows/copilot-deploy-backend.yml
@@ -26,12 +26,11 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   webapi:
     environment: ${{inputs.ENVIRONMENT}}
-    permissions:
-      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/copilot-deploy-memorypipeline.yml
+++ b/.github/workflows/copilot-deploy-memorypipeline.yml
@@ -22,12 +22,11 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   memorypipeline:
     environment: ${{inputs.ENVIRONMENT}}
-    permissions:
-      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/copilot-deploy-pipeline.yml
+++ b/.github/workflows/copilot-deploy-pipeline.yml
@@ -45,7 +45,7 @@ jobs:
       BACKEND_HOST: ${{needs.int.outputs.backend-host}}
 
   stable:
-    needs: int-tests
+    needs: [int-tests, build-webapi, build-memorypipeline, build-plugins]
     uses: ./.github/workflows/copilot-deploy-environment.yml
     with:
       ENVIRONMENT: stable

--- a/.github/workflows/copilot-deploy-plugins.yml
+++ b/.github/workflows/copilot-deploy-plugins.yml
@@ -22,12 +22,11 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   plugins:
     environment: ${{inputs.ENVIRONMENT}}
-    permissions:
-      id-token: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?  
  2. What problem does it solve?
  3. What scenario does it contribute to? 
  4. If it fixes an open issue, please link to the issue here.
-->

- The deployment workflows have a id-token permission at job level which overwrites the top-level. Not a problem if the repo is public but breaks it if you change to private.
- The "stable" environment deployment needs to depend on the earlier builds for artifact names and download-artifacts. Without them it, the "stable" deployment fails

### Description

- Moving id-token up ensures both permissions apply.
- Adding builds as "needs" for "stable" ensures dependencies are available for deployment

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
