### PR TITLE
Use IHttpClientFactory

### DIFF
--- a/webapi/Controllers/PluginController.cs
+++ b/webapi/Controllers/PluginController.cs
@@ -27,15 +27,18 @@ public class PluginController : ControllerBase
 {
     private const string PluginStateChanged = "PluginStateChanged";
     private readonly ILogger<PluginController> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IDictionary<string, Plugin> _availablePlugins;
     private readonly ChatSessionRepository _sessionRepository;
 
     public PluginController(
         ILogger<PluginController> logger,
+        IHttpClientFactory httpClientFactory,
         IDictionary<string, Plugin> availablePlugins,
         ChatSessionRepository sessionRepository)
     {
         this._logger = logger;
+        this._httpClientFactory = httpClientFactory;
         this._availablePlugins = availablePlugins;
         this._sessionRepository = sessionRepository;
     }
@@ -54,7 +57,7 @@ public class PluginController : ControllerBase
         // Need to set the user agent to avoid 403s from some sites.
         request.Headers.Add("User-Agent", Telemetry.HttpUserAgent);
 
-        using HttpClient client = new();
+        using HttpClient client = this._httpClientFactory.CreateClient("Plugin");
         var response = await client.SendAsync(request);
         if (!response.IsSuccessStatusCode)
         {

--- a/webapi/Controllers/SpeechTokenController.cs
+++ b/webapi/Controllers/SpeechTokenController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/webapi/Controllers/SpeechTokenController.cs
+++ b/webapi/Controllers/SpeechTokenController.cs
@@ -23,11 +23,15 @@ public class SpeechTokenController : ControllerBase
     }
 
     private readonly ILogger<SpeechTokenController> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly AzureSpeechOptions _options;
 
-    public SpeechTokenController(IOptions<AzureSpeechOptions> options, ILogger<SpeechTokenController> logger)
+    public SpeechTokenController(IOptions<AzureSpeechOptions> options,
+        ILogger<SpeechTokenController> logger,
+        IHttpClientFactory httpClientFactory)
     {
         this._logger = logger;
+        this._httpClientFactory = httpClientFactory;
         this._options = options.Value;
     }
 
@@ -55,16 +59,16 @@ public class SpeechTokenController : ControllerBase
 
     private async Task<TokenResult> FetchTokenAsync(string fetchUri, string subscriptionKey)
     {
-        // TODO: get the HttpClient from the DI container
-        using var client = new HttpClient();
-        client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-        UriBuilder uriBuilder = new(fetchUri);
+        using var client = this._httpClientFactory.CreateClient();
 
-        var result = await client.PostAsync(uriBuilder.Uri, null);
+        using var request = new HttpRequestMessage(HttpMethod.Post, fetchUri);
+        request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+
+        var result = await client.SendAsync(request);
         if (result.IsSuccessStatusCode)
         {
             var response = result.EnsureSuccessStatusCode();
-            this._logger.LogDebug("Token Uri: {0}", uriBuilder.Uri.AbsoluteUri);
+            this._logger.LogDebug("Token Uri: {0}", fetchUri);
             string token = await result.Content.ReadAsStringAsync();
             return new TokenResult { Token = token, ResponseCode = response.StatusCode };
         }

--- a/webapi/Extensions/SemanticKernelExtensions.cs
+++ b/webapi/Extensions/SemanticKernelExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Hubs;
@@ -169,7 +170,7 @@ internal static class SemanticKernelExtensions
 
     private static void InitializeKernelProvider(this WebApplicationBuilder builder)
     {
-        builder.Services.AddSingleton(sp => new SemanticKernelProvider(sp, builder.Configuration));
+        builder.Services.AddSingleton(sp => new SemanticKernelProvider(sp, builder.Configuration, sp.GetRequiredService<IHttpClientFactory>()));
     }
 
     /// <summary>

--- a/webapi/Program.cs
+++ b/webapi/Program.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -67,6 +68,14 @@ public sealed class Program
             .AddSingleton<ITelemetryService, AppInsightsTelemetryService>();
 
         TelemetryDebugWriter.IsTracingDisabled = Debugger.IsAttached;
+
+        // Add named HTTP clients for IHttpClientFactory
+        builder.Services.AddHttpClient();
+        builder.Services.AddHttpClient("Plugin", httpClient =>
+        {
+            int timeout = int.Parse(builder.Configuration["Planner:PluginTimeoutLimitInS"] ?? "100", CultureInfo.InvariantCulture);
+            httpClient.Timeout = TimeSpan.FromSeconds(timeout);
+        });
 
         // Add in the rest of the services.
         builder.Services

--- a/webapi/Services/SemanticKernelProvider.cs
+++ b/webapi/Services/SemanticKernelProvider.cs
@@ -27,11 +27,13 @@ public sealed class SemanticKernelProvider
 
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
+    private readonly IHttpClientFactory _httpClientFactory;
 
-    public SemanticKernelProvider(IServiceProvider serviceProvider, IConfiguration configuration)
+    public SemanticKernelProvider(IServiceProvider serviceProvider, IConfiguration configuration, IHttpClientFactory httpClientFactory)
     {
         this._serviceProvider = serviceProvider;
         this._configuration = configuration;
+        this._httpClientFactory = httpClientFactory;
     }
 
     /// <summary>
@@ -83,11 +85,15 @@ public sealed class SemanticKernelProvider
             case string x when x.Equals("AzureOpenAI", StringComparison.OrdinalIgnoreCase):
             case string y when y.Equals("AzureOpenAIText", StringComparison.OrdinalIgnoreCase):
                 var azureAIOptions = memoryOptions.GetServiceConfig<AzureOpenAIConfig>(this._configuration, "AzureOpenAIText");
-                return kernelBuilder.WithAzureChatCompletionService(azureAIOptions.Deployment, azureAIOptions.Endpoint, azureAIOptions.APIKey);
+#pragma warning disable CA2000 // Dispose objects before losing scope - No need to dispose of HttpClient instances from IHttpClientFactory
+                return kernelBuilder.WithAzureChatCompletionService(azureAIOptions.Deployment, azureAIOptions.Endpoint, azureAIOptions.APIKey,
+                                                                    httpClient: this._httpClientFactory.CreateClient());
 
             case string x when x.Equals("OpenAI", StringComparison.OrdinalIgnoreCase):
                 var openAIOptions = memoryOptions.GetServiceConfig<OpenAIConfig>(this._configuration, "OpenAI");
-                return kernelBuilder.WithOpenAIChatCompletionService(openAIOptions.TextModel, openAIOptions.APIKey);
+                return kernelBuilder.WithOpenAIChatCompletionService(openAIOptions.TextModel, openAIOptions.APIKey,
+                                                                     httpClient: this._httpClientFactory.CreateClient());
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
             default:
                 throw new ArgumentException($"Invalid {nameof(memoryOptions.TextGeneratorType)} value in 'SemanticMemory' settings.");
@@ -107,12 +113,15 @@ public sealed class SemanticKernelProvider
             case string x when x.Equals("AzureOpenAI", StringComparison.OrdinalIgnoreCase):
             case string y when y.Equals("AzureOpenAIText", StringComparison.OrdinalIgnoreCase):
                 var azureAIOptions = memoryOptions.GetServiceConfig<AzureOpenAIConfig>(this._configuration, "AzureOpenAIText");
-                return kernelBuilder.WithAzureChatCompletionService(plannerOptions.Model, azureAIOptions.Endpoint, azureAIOptions.APIKey);
+#pragma warning disable CA2000 // Dispose objects before losing scope - No need to dispose of HttpClient instances from IHttpClientFactory
+                return kernelBuilder.WithAzureChatCompletionService(plannerOptions.Model, azureAIOptions.Endpoint, azureAIOptions.APIKey,
+                                                                    httpClient: this._httpClientFactory.CreateClient());
 
             case string x when x.Equals("OpenAI", StringComparison.OrdinalIgnoreCase):
                 var openAIOptions = memoryOptions.GetServiceConfig<OpenAIConfig>(this._configuration, "OpenAI");
-                return kernelBuilder.WithOpenAIChatCompletionService(plannerOptions.Model, openAIOptions.APIKey);
-
+                return kernelBuilder.WithOpenAIChatCompletionService(plannerOptions.Model, openAIOptions.APIKey,
+                                                                     httpClient: this._httpClientFactory.CreateClient());
+#pragma warning restore CA2000 // Dispose objects before losing scope
             default:
                 throw new ArgumentException($"Invalid {nameof(memoryOptions.TextGeneratorType)} value in 'SemanticMemory' settings.");
         }
@@ -130,12 +139,15 @@ public sealed class SemanticKernelProvider
             case string x when x.Equals("AzureOpenAI", StringComparison.OrdinalIgnoreCase):
             case string y when y.Equals("AzureOpenAIEmbedding", StringComparison.OrdinalIgnoreCase):
                 var azureAIOptions = memoryOptions.GetServiceConfig<AzureOpenAIConfig>(this._configuration, "AzureOpenAIEmbedding");
-                return kernelBuilder.WithAzureTextEmbeddingGenerationService(azureAIOptions.Deployment, azureAIOptions.Endpoint, azureAIOptions.APIKey);
+#pragma warning disable CA2000 // Dispose objects before losing scope - No need to dispose of HttpClient instances from IHttpClientFactory
+                return kernelBuilder.WithAzureTextEmbeddingGenerationService(azureAIOptions.Deployment, azureAIOptions.Endpoint, azureAIOptions.APIKey,
+                                                                             httpClient: this._httpClientFactory.CreateClient());
 
             case string x when x.Equals("OpenAI", StringComparison.OrdinalIgnoreCase):
                 var openAIOptions = memoryOptions.GetServiceConfig<OpenAIConfig>(this._configuration, "OpenAI");
-                return kernelBuilder.WithOpenAITextEmbeddingGenerationService(openAIOptions.EmbeddingModel, openAIOptions.APIKey);
-
+                return kernelBuilder.WithOpenAITextEmbeddingGenerationService(openAIOptions.EmbeddingModel, openAIOptions.APIKey,
+                                                                              httpClient: this._httpClientFactory.CreateClient());
+#pragma warning restore CA2000 // Dispose objects before losing scope
             default:
                 throw new ArgumentException($"Invalid {nameof(memoryOptions.Retrieval.EmbeddingGeneratorType)} value in 'SemanticMemory' settings.");
         }


### PR DESCRIPTION
### Motivation and Context
To reduce the latency between for requests, we can re-use connections.

### Description
Use IHttpClientFactory to pool and re-use underlying HttpClientMessageHandler instances.

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
