### PR TITLE
Fix Document/Memory Removal when Chat Deleted

### DIFF
--- a/webapi/Extensions/ISemanticMemoryClientExtensions.cs
+++ b/webapi/Extensions/ISemanticMemoryClientExtensions.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using CopilotChat.Shared;
 using CopilotChat.WebApi.Models.Storage;
 using CopilotChat.WebApi.Services;
-using DocumentFormat.OpenXml.Office2010.Word;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Customer reported issue.  Thank you!

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- Extract documentId from partition link
- Parallelize tasks

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
