### PR TITLE
Revert updates to Microsoft.Azure.Functions.* packages for plugins

### DIFF
--- a/plugins/web-searcher/WebSearcher.csproj
+++ b/plugins/web-searcher/WebSearcher.csproj
@@ -8,10 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+    <!-- Make sure the app is thoroughly tested after any Microsoft.Azure.Functions.* package updates. -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/web-searcher/local.settings.json
+++ b/plugins/web-searcher/local.settings.json
@@ -1,7 +1,7 @@
 {
     "IsEncrypted": false,
     "Values": {
-        "AzureWebJobsStorage": "",
+        "AzureWebJobsStorage": "UseDevelopmentStorage=none",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
     },
     "Host": {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Azure functions tend to break silently when the `Microsoft.Azure.Functions.*` packages are not of the correct versions. With the current versions, the web-searcher plugin cannot find the functions using the function core tool, i.e. `func start`. 

### Description
Downgrade the `Microsoft.Azure.Functions.*` versions to previous ones that have been tested extensively.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
