### PR TITLE
Make deployment template more robust

### DIFF
--- a/scripts/deploy/main.bicep
+++ b/scripts/deploy/main.bicep
@@ -54,7 +54,7 @@ param webApiClientId string
 param frontendClientId string
 
 @description('Azure AD tenant ID for authenticating users')
-param azureAdTenantId string = environment().authentication.tenant
+param azureAdTenantId string
 
 @description('Azure AD cloud instance for authenticating users')
 param azureAdInstance string = environment().authentication.loginEndpoint

--- a/scripts/deploy/main.bicep
+++ b/scripts/deploy/main.bicep
@@ -45,16 +45,16 @@ param aiEndpoint string = ''
 
 @secure()
 @description('Azure OpenAI or OpenAI API key')
-param aiApiKey string = ''
+param aiApiKey string
 
 @description('Azure AD client ID for the backend web API')
-param webApiClientId string = ''
+param webApiClientId string
 
 @description('Azure AD client ID for the frontend')
-param frontendClientId string = ''
+param frontendClientId string
 
 @description('Azure AD tenant ID for authenticating users')
-param azureAdTenantId string = ''
+param azureAdTenantId string = environment().authentication.tenant
 
 @description('Azure AD cloud instance for authenticating users')
 param azureAdInstance string = environment().authentication.loginEndpoint
@@ -157,7 +157,7 @@ resource appServiceWeb 'Microsoft.Web/sites@2022-09-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
-    virtualNetworkSubnetId: virtualNetwork.properties.subnets[0].id
+    virtualNetworkSubnetId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[0].id : null
     siteConfig: {
       healthCheckPath: '/healthz'
     }
@@ -167,6 +167,9 @@ resource appServiceWeb 'Microsoft.Web/sites@2022-09-01' = {
 resource appServiceWebConfig 'Microsoft.Web/sites/config@2022-09-01' = {
   parent: appServiceWeb
   name: 'web'
+  dependsOn: [
+    webSubnetConnection
+  ]
   properties: {
     alwaysOn: false
     cors: {
@@ -435,7 +438,6 @@ resource appServiceWebDeploy 'Microsoft.Web/sites/extensions@2022-09-01' = if (d
   }
   dependsOn: [
     appServiceWebConfig
-    webSubnetConnection
   ]
 }
 
@@ -448,7 +450,7 @@ resource appServiceMemoryPipeline 'Microsoft.Web/sites@2022-09-01' = {
   }
   properties: {
     serverFarmId: appServicePlan.id
-    virtualNetworkSubnetId: virtualNetwork.properties.subnets[0].id
+    virtualNetworkSubnetId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[0].id : null
     siteConfig: {
       alwaysOn: true
     }
@@ -458,6 +460,9 @@ resource appServiceMemoryPipeline 'Microsoft.Web/sites@2022-09-01' = {
 resource appServiceMemoryPipelineConfig 'Microsoft.Web/sites/config@2022-09-01' = {
   parent: appServiceMemoryPipeline
   name: 'web'
+  dependsOn: [
+    memSubnetConnection
+  ]
   properties: {
     alwaysOn: true
     detailedErrorLoggingEnabled: true
@@ -623,7 +628,6 @@ resource appServiceMemoryPipelineDeploy 'Microsoft.Web/sites/extensions@2022-09-
   }
   dependsOn: [
     appServiceMemoryPipelineConfig
-    memSubnetConnection
   ]
 }
 
@@ -775,7 +779,7 @@ resource appServiceQdrant 'Microsoft.Web/sites@2022-09-01' = if (memoryStore == 
     httpsOnly: true
     reserved: true
     clientCertMode: 'Required'
-    virtualNetworkSubnetId: virtualNetwork.properties.subnets[1].id
+    virtualNetworkSubnetId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[1].id : null
     siteConfig: {
       numberOfWorkers: 1
       linuxFxVersion: 'DOCKER|qdrant/qdrant:latest'
@@ -783,7 +787,7 @@ resource appServiceQdrant 'Microsoft.Web/sites@2022-09-01' = if (memoryStore == 
       vnetRouteAllEnabled: true
       ipSecurityRestrictions: [
         {
-          vnetSubnetResourceId: virtualNetwork.properties.subnets[0].id
+          vnetSubnetResourceId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[0].id : null
           action: 'Allow'
           priority: 300
           name: 'Allow front vnet'
@@ -820,7 +824,7 @@ resource azureCognitiveSearch 'Microsoft.Search/searchServices@2022-09-01' = if 
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = if (memoryStore == 'Qdrant') {
   name: 'vnet-${uniqueName}'
   location: location
   properties: {
@@ -888,7 +892,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = {
   }
 }
 
-resource webNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
+resource webNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = if (memoryStore == 'Qdrant') {
   name: 'nsg-${uniqueName}-webapi'
   location: location
   properties: {
@@ -910,7 +914,7 @@ resource webNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
   }
 }
 
-resource qdrantNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
+resource qdrantNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = if (memoryStore == 'Qdrant') {
   name: 'nsg-${uniqueName}-qdrant'
   location: location
   properties: {
@@ -918,20 +922,20 @@ resource qdrantNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
   }
 }
 
-resource webSubnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2022-09-01' = {
+resource webSubnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2022-09-01' = if (memoryStore == 'Qdrant') {
   parent: appServiceWeb
   name: 'webSubnetConnection'
   properties: {
-    vnetResourceId: virtualNetwork.properties.subnets[0].id
+    vnetResourceId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[0].id : null
     isSwift: true
   }
 }
 
-resource memSubnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2022-09-01' = {
+resource memSubnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2022-09-01' = if (memoryStore == 'Qdrant') {
   parent: appServiceMemoryPipeline
   name: 'memSubnetConnection'
   properties: {
-    vnetResourceId: virtualNetwork.properties.subnets[0].id
+    vnetResourceId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[0].id : null
     isSwift: true
   }
 }
@@ -940,7 +944,7 @@ resource qdrantSubnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2
   parent: appServiceQdrant
   name: 'qdrantSubnetConnection'
   properties: {
-    vnetResourceId: virtualNetwork.properties.subnets[1].id
+    vnetResourceId: memoryStore == 'Qdrant' ? virtualNetwork.properties.subnets[1].id : null
     isSwift: true
   }
 }

--- a/scripts/deploy/main.json
+++ b/scripts/deploy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.22.6.54827",
-      "templateHash": "436459049279662194"
+      "version": "0.23.1.45101",
+      "templateHash": "12341117698294862245"
     }
   },
   "parameters": {
@@ -95,28 +95,25 @@
     },
     "aiApiKey": {
       "type": "securestring",
-      "defaultValue": "",
       "metadata": {
         "description": "Azure OpenAI or OpenAI API key"
       }
     },
     "webApiClientId": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "Azure AD client ID for the backend web API"
       }
     },
     "frontendClientId": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "Azure AD client ID for the frontend"
       }
     },
     "azureAdTenantId": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "[environment().authentication.tenant]",
       "metadata": {
         "description": "Azure AD tenant ID for authenticating users"
       }
@@ -281,7 +278,7 @@
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', format('asp-{0}-webapi', variables('uniqueName')))]",
         "httpsOnly": true,
-        "virtualNetworkSubnetId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id]",
+        "virtualNetworkSubnetId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id, null())]",
         "siteConfig": {
           "healthCheckPath": "/healthz"
         }
@@ -321,7 +318,8 @@
         "[resourceId('Microsoft.Web/sites', format('function-{0}-websearcher-plugin', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('cog-speech-{0}', variables('uniqueName')))]",
-        "[resourceId('Microsoft.Storage/storageAccounts', format('st{0}', variables('rgIdHash')))]"
+        "[resourceId('Microsoft.Storage/storageAccounts', format('st{0}', variables('rgIdHash')))]",
+        "[resourceId('Microsoft.Web/sites/virtualNetworkConnections', format('app-{0}-webapi', variables('uniqueName')), 'webSubnetConnection')]"
       ]
     },
     {
@@ -335,8 +333,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', format('app-{0}-webapi', variables('uniqueName')))]",
-        "[resourceId('Microsoft.Web/sites/config', format('app-{0}-webapi', variables('uniqueName')), 'web')]",
-        "[resourceId('Microsoft.Web/sites/virtualNetworkConnections', format('app-{0}-webapi', variables('uniqueName')), 'webSubnetConnection')]"
+        "[resourceId('Microsoft.Web/sites/config', format('app-{0}-webapi', variables('uniqueName')), 'web')]"
       ]
     },
     {
@@ -350,7 +347,7 @@
       },
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', format('asp-{0}-webapi', variables('uniqueName')))]",
-        "virtualNetworkSubnetId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id]",
+        "virtualNetworkSubnetId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id, null())]",
         "siteConfig": {
           "alwaysOn": true
         }
@@ -523,6 +520,7 @@
         "[resourceId('Microsoft.Web/sites', format('app-{0}-memorypipeline', variables('uniqueName')))]",
         "[resourceId('Microsoft.Web/sites', format('app-{0}-qdrant', variables('uniqueName')))]",
         "[resourceId('Microsoft.Search/searchServices', format('acs-{0}', variables('uniqueName')))]",
+        "[resourceId('Microsoft.Web/sites/virtualNetworkConnections', format('app-{0}-memorypipeline', variables('uniqueName')), 'memSubnetConnection')]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('cog-ocr-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName')))]",
         "[resourceId('Microsoft.Storage/storageAccounts', format('st{0}', variables('rgIdHash')))]"
@@ -539,8 +537,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', format('app-{0}-memorypipeline', variables('uniqueName')))]",
-        "[resourceId('Microsoft.Web/sites/config', format('app-{0}-memorypipeline', variables('uniqueName')), 'web')]",
-        "[resourceId('Microsoft.Web/sites/virtualNetworkConnections', format('app-{0}-memorypipeline', variables('uniqueName')), 'memSubnetConnection')]"
+        "[resourceId('Microsoft.Web/sites/config', format('app-{0}-memorypipeline', variables('uniqueName')), 'web')]"
       ]
     },
     {
@@ -720,7 +717,7 @@
         "httpsOnly": true,
         "reserved": true,
         "clientCertMode": "Required",
-        "virtualNetworkSubnetId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[1].id]",
+        "virtualNetworkSubnetId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[1].id, null())]",
         "siteConfig": {
           "numberOfWorkers": 1,
           "linuxFxVersion": "DOCKER|qdrant/qdrant:latest",
@@ -728,7 +725,7 @@
           "vnetRouteAllEnabled": true,
           "ipSecurityRestrictions": [
             {
-              "vnetSubnetResourceId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id]",
+              "vnetSubnetResourceId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id, null())]",
               "action": "Allow",
               "priority": 300,
               "name": "Allow front vnet"
@@ -772,6 +769,7 @@
       }
     },
     {
+      "condition": "[equals(parameters('memoryStore'), 'Qdrant')]",
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2021-05-01",
       "name": "[format('vnet-{0}', variables('uniqueName'))]",
@@ -845,6 +843,7 @@
       ]
     },
     {
+      "condition": "[equals(parameters('memoryStore'), 'Qdrant')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2022-11-01",
       "name": "[format('nsg-{0}-webapi', variables('uniqueName'))]",
@@ -868,6 +867,7 @@
       }
     },
     {
+      "condition": "[equals(parameters('memoryStore'), 'Qdrant')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2022-11-01",
       "name": "[format('nsg-{0}-qdrant', variables('uniqueName'))]",
@@ -877,11 +877,12 @@
       }
     },
     {
+      "condition": "[equals(parameters('memoryStore'), 'Qdrant')]",
       "type": "Microsoft.Web/sites/virtualNetworkConnections",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}/{1}', format('app-{0}-webapi', variables('uniqueName')), 'webSubnetConnection')]",
       "properties": {
-        "vnetResourceId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id]",
+        "vnetResourceId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id, null())]",
         "isSwift": true
       },
       "dependsOn": [
@@ -890,11 +891,12 @@
       ]
     },
     {
+      "condition": "[equals(parameters('memoryStore'), 'Qdrant')]",
       "type": "Microsoft.Web/sites/virtualNetworkConnections",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}/{1}', format('app-{0}-memorypipeline', variables('uniqueName')), 'memSubnetConnection')]",
       "properties": {
-        "vnetResourceId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id]",
+        "vnetResourceId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[0].id, null())]",
         "isSwift": true
       },
       "dependsOn": [
@@ -908,7 +910,7 @@
       "apiVersion": "2022-09-01",
       "name": "[format('{0}/{1}', format('app-{0}-qdrant', variables('uniqueName')), 'qdrantSubnetConnection')]",
       "properties": {
-        "vnetResourceId": "[reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[1].id]",
+        "vnetResourceId": "[if(equals(parameters('memoryStore'), 'Qdrant'), reference(resourceId('Microsoft.Network/virtualNetworks', format('vnet-{0}', variables('uniqueName'))), '2021-05-01').subnets[1].id, null())]",
         "isSwift": true
       },
       "dependsOn": [

--- a/scripts/deploy/main.json
+++ b/scripts/deploy/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "12341117698294862245"
+      "templateHash": "10280441124249350356"
     }
   },
   "parameters": {
@@ -113,7 +113,6 @@
     },
     "azureAdTenantId": {
       "type": "string",
-      "defaultValue": "[environment().authentication.tenant]",
       "metadata": {
         "description": "Azure AD tenant ID for authenticating users"
       }


### PR DESCRIPTION
### Motivation and Context
The templates are currently prone to failure.

### Description
- Only use virtual nets when using Qdrant (it seems _something_ with the virtual nets is causing deployments to often fail)
- Automatically populate azureAdTenantId
- Force user to provide an API key and client IDs (instead of allowing unusable deployments to be created)

### Contribution Checklist
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
