### PR TITLE
Fix 403's we get from OpenAI's website with the link checker

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -35,5 +35,16 @@
     429,
     500,
     503
+  ],
+  "httpHeaders": [
+    {
+      "urls": [
+        "https://platform.openai.com/"
+      ],
+      "headers": {
+        "User-Agent": "PostmanRuntime/7.33.0",
+        "Accept-Encoding": "br, gzip, deflate"
+      }
+    }
   ]
 }

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -20,5 +20,4 @@ jobs:
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
         config-file: ".github/workflows/markdown-link-check-config.json"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,8 +16,9 @@ jobs:
     - uses: actions/checkout@v4
 
     # Checks the status of hyperlinks in .md files in verbose mode
-    - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-verbose-mode: 'yes'
-        config-file: ".github/workflows/markdown-link-check-config.json"
+    #- name: Check links
+    #  uses: gaurav-nelson/github-action-markdown-link-check@v1
+    #  with:
+    #    use-quiet-mode: 'yes'
+    #    use-verbose-mode: 'yes'
+    #    config-file: ".github/workflows/markdown-link-check-config.json"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,9 +16,9 @@ jobs:
     - uses: actions/checkout@v4
 
     # Checks the status of hyperlinks in .md files in verbose mode
-    #- name: Check links
-    #  uses: gaurav-nelson/github-action-markdown-link-check@v1
-    #  with:
-    #    use-quiet-mode: 'yes'
-    #    use-verbose-mode: 'yes'
-    #    config-file: ".github/workflows/markdown-link-check-config.json"
+    - name: Check links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: ".github/workflows/markdown-link-check-config.json"


### PR DESCRIPTION
### Motivation and Context
The link checker fails on platform.openai.com links

### Description
Add headers required by platform.openai.com

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
