### PR TITLE
Fixing conversation filtering

### DIFF
--- a/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -83,7 +83,6 @@ const useClasses = makeStyles({
 });
 
 interface ConversationsView {
-    filteredConversations?: Conversations;
     latestConversations?: Conversations;
     olderConversations?: Conversations;
 }

--- a/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -12,6 +12,7 @@ import {
 } from '@fluentui/react-components';
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { useChat, useFile } from '../../../libs/hooks';
+import { getFriendlyChatName } from '../../../libs/hooks/useChat';
 import { AlertType } from '../../../libs/models/AlertType';
 import { ChatArchive } from '../../../libs/models/ChatArchive';
 import { useAppDispatch, useAppSelector } from '../../../redux/app/hooks';
@@ -136,7 +137,11 @@ export const ChatList: FC = () => {
         const nonHiddenConversations: Conversations = {};
         for (const key in conversations) {
             const conversation = conversations[key];
-            if (!conversation.hidden && (!filterText || conversation.title.toLowerCase().includes(filterText))) {
+            if (
+                !conversation.hidden &&
+                (!filterText ||
+                    getFriendlyChatName(conversation).toLocaleUpperCase().includes(filterText.toLocaleUpperCase()))
+            ) {
                 nonHiddenConversations[key] = conversation;
             }
         }
@@ -207,21 +212,11 @@ export const ChatList: FC = () => {
                 )}
             </div>
             <div aria-label={'chat list'} className={classes.list}>
-                {isFiltering && filterText.length > 0 ? (
-                    <>
-                        {conversationsView.filteredConversations && (
-                            <ChatListSection conversations={conversationsView.filteredConversations} />
-                        )}
-                    </>
-                ) : (
-                    <>
-                        {conversationsView.latestConversations && (
-                            <ChatListSection header="Today" conversations={conversationsView.latestConversations} />
-                        )}
-                        {conversationsView.olderConversations && (
-                            <ChatListSection header="Older" conversations={conversationsView.olderConversations} />
-                        )}
-                    </>
+                {conversationsView.latestConversations && (
+                    <ChatListSection header="Today" conversations={conversationsView.latestConversations} />
+                )}
+                {conversationsView.olderConversations && (
+                    <ChatListSection header="Older" conversations={conversationsView.olderConversations} />
                 )}
             </div>
         </div>


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR removes part of the isFiltering conversations view state, including an unnecessary filteredConversations field, since @TaoChenOSU's filters and sorts the conversations into the expected Latest and Older conversations lists.

Also, fixes a bug so the filter is applied to the client view name, rather than the actual saved name on the object since this is what our end user sees and would expect the search text to check against.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
