### PR TITLE
Do not trigger e2e test when a PR is approved

### DIFF
--- a/.github/workflows/copilot-test-e2e.yml
+++ b/.github/workflows/copilot-test-e2e.yml
@@ -3,15 +3,12 @@ on:
   workflow_dispatch:
   merge_group:
     types: [checks_requested]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: read
 
 jobs:
   e2e:
-    if: github.event.review.state == 'APPROVED' || github.event_name == 'workflow_dispatch'
     defaults:
       run:
         working-directory: webapp


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The e2e test action is still having some issue starting the service. The action keeps failing and blocking PRs from merging.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Do not trigger this action when a PR is approved. 


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
