### PR TITLE
Copy static files in proper folder

### DIFF
--- a/integration-tests/StaticFiles.cs
+++ b/integration-tests/StaticFiles.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Net.Http;
+using Xunit;
+
+namespace ChatCopilotIntegrationTests;
+
+public class StaticFiles : ChatCopilotIntegrationTest
+{
+    [Fact]
+    public async void GetStaticFiles()
+    {
+        HttpResponseMessage response = await this._httpClient.GetAsync("index.html");
+        response.EnsureSuccessStatusCode();
+        Assert.True(response.Content.Headers.ContentLength > 1);
+
+        response = await this._httpClient.GetAsync("favicon.ico");
+        response.EnsureSuccessStatusCode();
+        Assert.True(response.Content.Headers.ContentLength > 1);
+    }
+}

--- a/scripts/deploy/package-webapi.ps1
+++ b/scripts/deploy/package-webapi.ps1
@@ -87,7 +87,7 @@ if (-Not $SkipFrontendFiles) {
     Pop-Location
 
     Write-Host "Copying frontend files to package"
-    Copy-Item -Path "$PSScriptRoot/../../webapp/build" -Destination "$publishOutputDirectory\wwwroot" -Recurse -Force
+    Copy-Item -Path "$PSScriptRoot/../../webapp/build/*" -Destination "$publishOutputDirectory\wwwroot" -Recurse -Force
 }
 
 Write-Host "Compressing package to $publishedZipFilePath"

--- a/scripts/deploy/package-webapi.sh
+++ b/scripts/deploy/package-webapi.sh
@@ -138,7 +138,7 @@ if [[ -z "$SKIP_FRONTEND" ]]; then
     popd
 
     echo "Copying frontend files to package"
-    cp -R "$SCRIPT_ROOT/../../webapp/build" "$PUBLISH_OUTPUT_DIRECTORY/wwwroot"
+    cp -R "$SCRIPT_ROOT/../../webapp/build/." "$PUBLISH_OUTPUT_DIRECTORY/wwwroot"
 fi
 
 # if not NO_ZIP then zip the package


### PR DESCRIPTION
### Motivation and Context
We want static files to be properly served by the backend

### Description
- Copy folder contents of "build" instead of folder itself
- Add int test to check for presence of static files

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
