### PR TITLE
Issue #701 updated readme.md for webapi to make it clearer how one can include plugins in build output for publishing

### DIFF
--- a/webapi/README.md
+++ b/webapi/README.md
@@ -301,6 +301,14 @@ Alternatively,
     </Content>
    ```
 
+   You will also need to include a line for each skprompt.txt file you have for you plugins to ensure they are included in the build output.
+
+   ```xml
+   <None Update="Plugins\SemanticPlugins\{PluginName}\skprompt.txt">
+     <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+   </None>
+   ```
+
 3. Change the respective directory option to use an absolute path or a different base path, but make sure that the files are accessible from that location.
 
 ### Add Custom Setup to Chat Copilot's Kernel


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? Issue #701 
  2. What problem does it solve? Not clear in readme that this step is needed in order to publish plugins
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here. #701 
-->

### Description

Readme updated with example of what is required to include prompt.txt in build output


