### PR TITLE
Ignore stackoverflow links in markdown-link-check process because it …

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -26,6 +26,9 @@
     },
     {
       "pattern": "^https://platform.openai.com"
+    },
+    {
+      "pattern": "^https://stackoverflow.com"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
…makes it choke

### Motivation and Context
We want PRs to succeed, but this link makes them fail

### Description
Ignore stackoverflow links

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
