### PR TITLE
Removed token count of user message

### DIFF
--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -626,7 +626,6 @@ public class ChatPlugin
         return this._promptOptions.CompletionTokenLimit
             - ExtraOpenAiMessageTokens
             - TokenUtils.GetContextMessagesTokenCount(promptTemplate)
-            - TokenUtils.GetContextMessageTokenCount(AuthorRole.User, userInput) // User message has to be included in chat history allowance
             - this._promptOptions.ResponseTokenLimit;
     }
 


### PR DESCRIPTION
### Motivation and Context

1. Why is this change required?
The user message is not added to the GPT completion request when the token count of the prompt exceeds 50% of the configuration.
2. What problem does it solve?
We can now use large prompts in ChatCopilot.

### Description

The method `GetChatContextTokenLimit` from `ChatPlugin` was used to count the user message, indicating that it needed to be added. However, it was never added directly; instead, it was added by the `GetAllowedChatHistoryAsync` method.

For example, if you have a configuration with:
- `CompletionTokenLimit`: 4096
- `ResponseTokenLimit`: 1024

and the following prompt:

> You are a specialist in HR and recruitment.
> You analyze the transcript of an interview in relation to a job offer announcement.
> Here is the announcement
> [START OFFER]
> {{Offer content that has more than 1000 tokens}}
> [END OFFER]
> Here is the transcript of the interview
> [START TRANSCRIPT]
> {{meeting transcript that has more than 1000 tokens}}
> [END TRANSCRIPT]
> Give me the list of 5 positive and negative points about the candidate in relation to the announcement
> Give me a rating out of 5 for the candidate

You end up with a completion request that only contains the user intent, and the bot responds with:
> Sure, I can help with that. Can you provide me with more details about the candidate and the job posting?

Note: We could also address this issue by adding the user message directly into the chat history and ensuring that the message is not added a second time in `GetAllowedChatHistoryAsync`.