### PR TITLE
Provide only correct names to ConfigureQueueDependency()

### DIFF
--- a/shared/ServiceConfiguration.cs
+++ b/shared/ServiceConfiguration.cs
@@ -130,14 +130,12 @@ internal sealed class ServiceConfiguration
                 case string y1 when y1.Equals("AzureQueue", StringComparison.OrdinalIgnoreCase):
                 case string y2 when y2.Equals("AzureQueues", StringComparison.OrdinalIgnoreCase):
                     // Check 2 keys for backward compatibility
-                    builder.Services.AddAzureQueuesOrchestration(this.GetServiceConfig<AzureQueuesConfig>("AzureQueues")
-                                                                 ?? this.GetServiceConfig<AzureQueuesConfig>("AzureQueue"));
+                    builder.Services.AddAzureQueuesOrchestration(this.GetServiceConfig<AzureQueuesConfig>("AzureQueue"));
                     break;
 
                 case string y when y.Equals("RabbitMQ", StringComparison.OrdinalIgnoreCase):
                     // Check 2 keys for backward compatibility
-                    builder.Services.AddRabbitMQOrchestration(this.GetServiceConfig<RabbitMqConfig>("RabbitMQ")
-                                                              ?? this.GetServiceConfig<RabbitMqConfig>("RabbitMq"));
+                    builder.Services.AddRabbitMQOrchestration(this.GetServiceConfig<RabbitMqConfig>("RabbitMq"));
                     break;
 
                 case string y when y.Equals("SimpleQueues", StringComparison.OrdinalIgnoreCase):

--- a/webapi/appsettings.json
+++ b/webapi/appsettings.json
@@ -238,7 +238,7 @@
         "Auth": "ConnectionString",
         //"ConnectionString": "", // dotnet user-secrets set "KernelMemory:Services:AzureBlobs:ConnectionString" "MY_AZUREBLOB_CONNECTIONSTRING"
         //"Account": "",
-        "Container": "memorypipeline"
+        "Container": "chatmemory"
         //"EndpointSuffix": "core.windows.net"
       },
       //


### PR DESCRIPTION
### Motivation and Context
Due to changes in KernelMemory, providing alternative names now causes the system to die.

### Description
Only provide correct config section names.

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
