### PR TITLE
Fixes #851 : relevanceThreshold is not utilized preventing additional memory items

### DIFF
--- a/webapi/Extensions/ISemanticMemoryClientExtensions.cs
+++ b/webapi/Extensions/ISemanticMemoryClientExtensions.cs
@@ -99,7 +99,7 @@ internal static class ISemanticMemoryClientExtensions
                 indexName,
                 filter,
                 null,
-                0,
+                relevanceThreshold, // minRelevance param
                 resultCount,
                 cancellationToken);
 


### PR DESCRIPTION
fix bug related to issue #851.
Unused parameter relevanceThreshold is passed to SearchAsync method to ensure only relevant documents are fetched.

### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. The code change is related because current code retrieves all memory items regardless of similarity which prevents adding new memory items. Check SemanticChatMemoryExtractor.ExtractCognitiveMemoryAsync.
  2. The issue is only the first memory item is preserved. Additional memory items are lost because they always seem to be similar to the first memory item.
  3. With this fix, a memory item is skipped only if there is similar memory item in the memory. As a result distinct memory items will be preserved.
  4. It fixes an open issue #851 .

### Description

The chance is simple, it utilizes unutilized relevanceThreshold parameter in ISemanticMemoryClientExtensions.SearchAsync method. SemanticChatMemoryExtractor.ExtractCognitiveMemoryAsync sends an upper threshold to find similar items, but since it is not used all non relevant memory items are returned.  

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [?] All unit tests pass, and I have added new tests where possible. I could not find any unit tests to run or extend. Please point out if there are any tests relevant to memory retrieval.
- [X] I didn't break anyone :smile:
