### PR TITLE
Initializing msal instance before handling redirect to fix race condi…

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -41,11 +41,27 @@ export function renderApp() {
             if (AuthHelper.isAuthAAD()) {
                 if (!msalInstance) {
                     msalInstance = new PublicClientApplication(AuthHelper.getMsalConfig(authConfig));
-                    void msalInstance.handleRedirectPromise().then((response) => {
-                        if (response) {
-                            msalInstance?.setActiveAccount(response.account);
-                        }
-                    });
+                    msalInstance
+                        .initialize()
+                        .then(() => {
+                            if (!msalInstance) {
+                                store.dispatch(setAuthConfig(undefined));
+                                return;
+                            }
+                            msalInstance
+                                .handleRedirectPromise()
+                                .then((response) => {
+                                    if (response) {
+                                        msalInstance?.setActiveAccount(response.account);
+                                    }
+                                })
+                                .catch(() => {
+                                    store.dispatch(setAuthConfig(undefined));
+                                });
+                        })
+                        .catch(() => {
+                            store.dispatch(setAuthConfig(undefined));
+                        });
                 }
 
                 // render with the MsalProvider if AAD is enabled


### PR DESCRIPTION
Initializing msal instance before handling redirect to fix race condition when deployed to Azure.

### Motivation and Context

We have reports of an 'uninitialized_public_client_application' error when loading the webApp after deploying to Azure.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
