### PR TITLE
fix: remove chat memories not selecting the right document id values /webapi

### DIFF
--- a/webapi/Extensions/ISemanticMemoryClientExtensions.cs
+++ b/webapi/Extensions/ISemanticMemoryClientExtensions.cs
@@ -183,7 +183,7 @@ internal static class ISemanticMemoryClientExtensions
         CancellationToken cancellationToken = default)
     {
         var memories = await memoryClient.SearchMemoryAsync(indexName, "*", 0.0F, chatId, cancellationToken: cancellationToken);
-        var documentIds = memories.Results.Select(memory => memory.Link.Split('/').First()).Distinct().ToArray();
+        var documentIds = memories.Results.Select(memory => memory.DocumentId).Distinct().ToArray();
         var tasks = documentIds.Select(documentId => memoryClient.DeleteDocumentAsync(documentId, indexName, cancellationToken)).ToArray();
 
         Task.WaitAll(tasks, cancellationToken);


### PR DESCRIPTION
### Motivation and Context
The current implementation does not delete chat documents and embeddings.

Fixes microsoft/chat-copilot#946

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

This change allows us to delete chat documents and vectors when a chat is deleted to avoid keeping unused documents and vectors in the memory store

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
